### PR TITLE
Add Dockerfile with instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:3.6
+RUN apk --no-cache add nodejs-current nodejs-npm
+RUN npm set progress=false && npm install -g nba-go
+CMD ["nba-go", "game", "-t"]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ All data comes from [stats.nba.com](http://stats.nba.com/) APIs.
 $ npm install -g nba-go
 ```
 
+Or in a Docker Container:
+
+```
+$ docker build -t nba-go:latest .
+$ docker run -it nba-go:latest
+```
+
+By default, the docker container will run `nba-go game -t`, but you can
+override this command at run time. For example:
+
+```
+$ docker run -it nba-go:latest nba-go player Curry -i
+```
+
 ## Usage
 
 `nba-go` provides two main commands.  


### PR DESCRIPTION
This Dockerfile just allows end users to consume the tool using
a Docker container vs installing a ton of node dependencies locally.