### PR TITLE
Default to help when no arguments passed in

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -149,4 +149,6 @@ program.command('*').action(command => {
   process.exit(1);
 });
 
+if (process.argv.length === 2) program.help();
+
 program.parse(process.argv);


### PR DESCRIPTION
I saw an issue wanting help displayed when no arguments are passed in 😄 