### PR TITLE
Fix date timezone problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "inquirer": "^4.0.0",
     "is-async-supported": "^1.2.0",
     "log-update": "^2.2.0",
+    "moment-timezone": "^0.5.14",
     "nba": "^4.0.0",
     "nba-color": "^1.2.2",
     "nba-stats-client": "^0.0.4",

--- a/src/cli.js
+++ b/src/cli.js
@@ -21,7 +21,12 @@ if (!isAsyncSupported()) {
   }).notify({ defer: false });
 })();
 
-program.version(pkg.version);
+program.version(
+  `\n${chalk`{bold.hex('#0069b9') NBA}`} ${nbaRed('GO')} version: ${
+    pkg.version
+  }\n`,
+  '-v, --version'
+);
 
 program
   .command('player <name>')
@@ -134,8 +139,6 @@ program.on('--help', () => {
   );
   console.log('');
 });
-
-program.option('-v --version', pkg.version);
 
 program.command('*').action(command => {
   error(`Unknown command: ${bold(command)}`);

--- a/src/command/game/index.js
+++ b/src/command/game/index.js
@@ -21,16 +21,7 @@ import NBA from '../../utils/nba';
 import { error, bold } from '../../utils/log';
 import { cfontsDate } from '../../utils/cfonts';
 import getBlessed from '../../utils/blessed';
-
-const catchError = (err, apiName) => {
-  error(err);
-  console.log('');
-  error(`Oops, ${apiName} goes wrong.`);
-  error(
-    'Please run nba-go again.\nIf it still does not work, feel free to open an issue on https://github.com/xxhomey19/nba-go/issues'
-  );
-  process.exit(1);
-};
+import catchAPIError from '../../utils/catchAPIError';
 
 const getSeason = date => {
   const year = getYear(new Date(date));
@@ -113,7 +104,7 @@ const game = async option => {
     } = await NBA.getGamesFromDate(new Date(_date));
     gamesData = _gamesData;
   } catch (err) {
-    catchError(err, 'NBA.getGamesFromDate()');
+    catchAPIError(err, 'NBA.getGamesFromDate()');
   }
 
   const {
@@ -131,7 +122,7 @@ const game = async option => {
     gameBoxScoreData = _gameBoxScoreData;
     seasonMetaData = _seasonMetaData;
   } catch (err) {
-    catchError(err, 'NBA.getBoxScoreFromDate()');
+    catchAPIError(err, 'NBA.getBoxScoreFromDate()');
   }
 
   const { home, visitor } = gameBoxScoreData;
@@ -183,7 +174,7 @@ const game = async option => {
         homeTeamDashboardData = _homeTeamDashboardData;
         visitorTeamDashboardData = _visitorTeamDashboardData;
       } catch (err) {
-        catchError(err, 'NBA.teamSplits()');
+        catchAPIError(err, 'NBA.teamSplits()');
       }
 
       spinner.stop();
@@ -226,7 +217,7 @@ const game = async option => {
 
           updatedPlayByPlayData = _updatedPlayByPlayData;
         } catch (err) {
-          catchError(err, 'NBA.getPlayByPlayFromDate()');
+          catchAPIError(err, 'NBA.getPlayByPlayFromDate()');
         }
 
         try {
@@ -236,7 +227,7 @@ const game = async option => {
 
           updatedGameBoxScoreData = _updatedGameBoxScoreData;
         } catch (err) {
-          catchError(err, 'NBA.getBoxScoreFromDate()');
+          catchAPIError(err, 'NBA.getBoxScoreFromDate()');
         }
 
         gamePlayByPlayData = updatedPlayByPlayData;

--- a/src/command/player/index.js
+++ b/src/command/player/index.js
@@ -5,17 +5,7 @@ import playerInfo from './info';
 import seasonStats from './seasonStats';
 
 import NBA from '../../utils/nba';
-import { error } from '../../utils/log';
-
-const catchError = (err, apiName) => {
-  error(err);
-  console.log('');
-  error(`Oops, ${apiName} goes wrong.`);
-  error(
-    'Please run nba-go again.\nIf it still does not work, feel free to open an issue on https://github.com/xxhomey19/nba-go/issues'
-  );
-  process.exit(1);
-};
+import catchAPIError from '../../utils/catchAPIError';
 
 const player = async (playerName, option) => {
   await NBA.updatePlayers();
@@ -39,7 +29,7 @@ const player = async (playerName, option) => {
         commonPlayerInfo = _commonPlayerInfo;
         playerHeadlineStats = _playerHeadlineStats;
       } catch (err) {
-        catchError(err, 'NBA.playerInfo()');
+        catchAPIError(err, 'NBA.playerInfo()');
       }
 
       if (option.info) {
@@ -61,7 +51,7 @@ const player = async (playerName, option) => {
           seasonTotalsRegularSeason = _seasonTotalsRegularSeason;
           careerTotalsRegularSeason = _careerTotalsRegularSeason;
         } catch (err) {
-          catchError(err, 'NBA.playerProfile()');
+          catchAPIError(err, 'NBA.playerProfile()');
         }
 
         commonPlayerInfo[0].nowTeamAbbreviation =
@@ -89,7 +79,7 @@ const player = async (playerName, option) => {
           seasonTotalsPostSeason = _seasonTotalsPostSeason;
           careerTotalsPostSeason = _careerTotalsPostSeason;
         } catch (err) {
-          catchError(err, 'NBA.playerProfile()');
+          catchAPIError(err, 'NBA.playerProfile()');
         }
 
         if (careerTotalsPostSeason.length === 0) {

--- a/src/utils/__tests__/catchAPIError.spec.js
+++ b/src/utils/__tests__/catchAPIError.spec.js
@@ -1,0 +1,18 @@
+import catchAPIError from '../catchAPIError';
+import { error } from '../log';
+
+jest.mock('../log');
+process.exit = jest.fn();
+
+describe('catchAPIError', () => {
+  it('should exist', () => {
+    expect(catchAPIError).toBeDefined();
+  });
+
+  it('should work', () => {
+    catchAPIError('error message', 'NBA.getGamesFromDate()');
+
+    expect(error).toBeCalledWith('error message');
+    expect(process.exit).toBeCalledWith(1);
+  });
+});

--- a/src/utils/catchAPIError.js
+++ b/src/utils/catchAPIError.js
@@ -1,0 +1,13 @@
+import { error } from './log';
+
+const catchAPIError = (err, apiName) => {
+  error(err);
+  console.log('');
+  error(`Oops, ${apiName} goes wrong.`);
+  error(
+    'Please run nba-go again.\nIf it still does not work, feel free to open an issue on https://github.com/xxhomey19/nba-go/issues'
+  );
+  process.exit(1);
+};
+
+export default catchAPIError;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3462,6 +3462,16 @@ minimist@~0.0.1:
   dependencies:
     minimist "0.0.8"
 
+moment-timezone@^0.5.14:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.14.tgz#4eb38ff9538b80108ba467a458f3ed4268ccfcb1"
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0":
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
+
 moment@^2.15.1:
   version "2.19.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.1.tgz#56da1a2d1cbf01d38b7e1afc31c10bcfa1929167"


### PR DESCRIPTION
Fix #2 #28 

No matter which timezone user is in, nba-go will convert the input date's timezone to LA timezone.
This should fit API date.

e.g.
I'm in +8 timezone. If I enter `nba-go game -t` on 2018-01-24, the timestamp will be converted to LA timezone, then pass `2018-01-23` to NBA API. Finally, I get correct game schedule.