### PR TITLE
Network feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ $ nba-go game -T
 ![game -T gif](https://user-images.githubusercontent.com/12113222/32414142-7897dfe0-c25b-11e7-9acf-d50ade5379fd.gif)
 
 ##### `-n` or `--networks`
-Display on schedule home and away television network information.
+Display on schedule home team and away team television network information.
 
 ```
 $ nba-go game -n

--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ $ nba-go game -T
 
 ![game -T gif](https://user-images.githubusercontent.com/12113222/32414142-7897dfe0-c25b-11e7-9acf-d50ade5379fd.gif)
 
+##### `-n` or `--networks`
+Display on schedule home and away television network information.
+
+```
+$ nba-go game -n
+```
+
 #### Pregame  
 ⭐️⭐️  
 Check the detailed comparison data between two teams in the game.  

--- a/src/__tests__/cli.spec.js
+++ b/src/__tests__/cli.spec.js
@@ -138,6 +138,14 @@ describe('cli', () => {
       expect(nbaGo.game.mock.calls[0][0].tomorrow).toBe(true);
     });
 
+    it('should call nbaGo with option -n', () => {
+      process.argv = ['node', 'bin/cli.js', 'game', '-n'];
+
+      setup();
+
+      expect(nbaGo.game.mock.calls[0][0].networks).toBe(true);
+    });
+
     it('alias should work', () => {
       process.argv = ['node', 'bin/cli.js', 'p', 'Curry'];
       setup();

--- a/src/cli.js
+++ b/src/cli.js
@@ -72,7 +72,7 @@ program
   .option('-t, --today', "Watch today's games")
   .option('-T, --tomorrow', "Watch tomorrow's games")
   .option('-f, --filter <filter>', 'Filter game choices to watch')
-  .option('-b, --broadcasts', 'See television broadcast information')
+  .option('-n, --networks', 'See the networks game is/was televised on.')
   .on('--help', () => {
     console.log('');
     console.log('  Watch NBA live play-by-play, game preview and box score.');

--- a/src/cli.js
+++ b/src/cli.js
@@ -72,6 +72,7 @@ program
   .option('-t, --today', "Watch today's games")
   .option('-T, --tomorrow', "Watch tomorrow's games")
   .option('-f, --filter <filter>', 'Filter game choices to watch')
+  .option('-b, --broadcasts', 'See television broadcast information')
   .on('--help', () => {
     console.log('');
     console.log('  Watch NBA live play-by-play, game preview and box score.');

--- a/src/command/game/index.js
+++ b/src/command/game/index.js
@@ -219,7 +219,7 @@ const game = async option => {
         `${emoji.get('house')}  ${arena} | ${city}, ${state}`
       );
       networkText.setContent(
-        `${networks.homeTeam}  ${emoji.get('tv')}  ${networks.visitorTeam}`
+        `${networks.homeTeam} ${emoji.get('tv')}  ${networks.visitorTeam}`
       );
       while (true) {
         let gamePlayByPlayData = {};

--- a/src/command/game/index.js
+++ b/src/command/game/index.js
@@ -53,10 +53,10 @@ const getSeason = date => {
   return date;
 };
 
-const getGameWithOptionalFilter = async (games, filter) => {
-  if (filter && filter.split('=')[0] === 'team') {
+const getGameWithOptionalFilter = async (games, option) => {
+  if (option.filter && option.filter.split('=')[0] === 'team') {
     // TODO: Add more robust filtering but use team as proof of concept
-    const components = filter.split('=');
+    const components = option.filter.split('=');
     const team = components[1].toLowerCase();
     const potentialGames = games.filter(
       data =>
@@ -77,7 +77,7 @@ const getGameWithOptionalFilter = async (games, filter) => {
     } else return chooseGameFromSchedule(potentialGames);
   }
 
-  return chooseGameFromSchedule(games);
+  return chooseGameFromSchedule(games, option);
 };
 
 const game = async option => {
@@ -103,7 +103,6 @@ const game = async option => {
     error(`Can't find any option ${emoji.get('confused')}`);
     process.exit(1);
   }
-
   R.compose(cfontsDate, getSeason)(_date);
 
   const LADate = getLosAngelesTimezone(_date);
@@ -116,11 +115,9 @@ const game = async option => {
   } catch (err) {
     catchAPIError(err, 'NBA.getGamesFromDate()');
   }
-
   const {
     game: { homeTeam, visitorTeam, gameData },
-  } = await getGameWithOptionalFilter(gamesData, option.filter);
-
+  } = await getGameWithOptionalFilter(gamesData, option);
   try {
     const {
       sports_content: {

--- a/src/command/game/index.js
+++ b/src/command/game/index.js
@@ -149,9 +149,9 @@ const game = async option => {
     dateText,
     arenaText,
     homeTeamScoreText,
-    homeTeamBroadcastText,
+    homeTeamNetworkText,
     visitorTeamScoreText,
-    visitorTeamBroadcastText,
+    visitorTeamNetworkText,
     playByPlayBox,
     boxscoreTable,
   } = getBlessed(homeTeam, visitorTeam);
@@ -207,25 +207,25 @@ const game = async option => {
       );
       const { arena, city, state, date, time, broadcasters } = gameBoxScoreData;
 
-      const broadcastersTV = broadcasters.tv.broadcaster;
-      let homeTeamBroadcast = broadcastersTV.filter(
+      const televisionNetworks = broadcasters.tv.broadcaster;
+      let homeTeamNetwork = televisionNetworks.filter(
         broadcaster => broadcaster.home_visitor === 'home'
       );
-      let visitorTeamBroadcast = broadcastersTV.filter(
+      let visitorTeamNetwork = televisionNetworks.filter(
         broadcaster => broadcaster.home_visitor === 'visitor'
       );
-      let nationalBroadcast = broadcastersTV.filter(
+      let nationalNetwork = televisionNetworks.filter(
         broadcaster => broadcaster.home_visitor === 'natl'
       );
-      nationalBroadcast = !nationalBroadcast.length
+      nationalNetwork = !nationalNetwork.length
         ? 'N/A'
-        : nationalBroadcast[0].display_name;
-      homeTeamBroadcast = !homeTeamBroadcast.length
-        ? nationalBroadcast
-        : homeTeamBroadcast[0].display_name;
-      visitorTeamBroadcast = !visitorTeamBroadcast.length
-        ? nationalBroadcast
-        : visitorTeamBroadcast[0].display_name;
+        : nationalNetwork[0].display_name;
+      homeTeamNetwork = !homeTeamNetwork.length
+        ? nationalNetwork
+        : homeTeamNetwork[0].display_name;
+      visitorTeamNetwork = !visitorTeamNetwork.length
+        ? nationalNetwork
+        : visitorTeamNetwork[0].display_name;
 
       dateText.setContent(
         `${emoji.get('calendar')}  ${format(date, 'YYYY/MM/DD')} ${time.slice(
@@ -236,13 +236,10 @@ const game = async option => {
       arenaText.setContent(
         `${emoji.get('house')}  ${arena} | ${city}, ${state}`
       );
-      homeTeamBroadcastText.setContent(
-        `${homeTeamBroadcast}  ${emoji.get('tv')}`
-      );
-      homeTeamBroadcastText.position.left = `30%-${homeTeamBroadcast.length +
-        24}`;
-      visitorTeamBroadcastText.setContent(
-        `${emoji.get('tv')}  ${visitorTeamBroadcast}`
+      homeTeamNetworkText.setContent(`${homeTeamNetwork}  ${emoji.get('tv')}`);
+      homeTeamNetworkText.position.left = `30%-${homeTeamNetwork.length + 24}`;
+      visitorTeamNetworkText.setContent(
+        `${emoji.get('tv')}  ${visitorTeamNetwork}`
       );
       while (true) {
         let gamePlayByPlayData = {};

--- a/src/command/game/index.js
+++ b/src/command/game/index.js
@@ -18,6 +18,7 @@ import preview from './preview';
 import scoreboard from './scoreboard';
 import boxScore from './boxScore';
 import live from './live';
+import getBroadcastNetworks from './network';
 
 import NBA from '../../utils/nba';
 import { error, bold } from '../../utils/log';
@@ -206,25 +207,7 @@ const game = async option => {
       );
       const { arena, city, state, date, time, broadcasters } = gameBoxScoreData;
 
-      const televisionNetworks = broadcasters.tv.broadcaster;
-      let homeTeamNetwork = televisionNetworks.filter(
-        broadcaster => broadcaster.home_visitor === 'home'
-      );
-      let visitorTeamNetwork = televisionNetworks.filter(
-        broadcaster => broadcaster.home_visitor === 'visitor'
-      );
-      let nationalNetwork = televisionNetworks.filter(
-        broadcaster => broadcaster.home_visitor === 'natl'
-      );
-      nationalNetwork = !nationalNetwork.length
-        ? 'N/A'
-        : nationalNetwork[0].display_name;
-      homeTeamNetwork = !homeTeamNetwork.length
-        ? nationalNetwork
-        : homeTeamNetwork[0].display_name;
-      visitorTeamNetwork = !visitorTeamNetwork.length
-        ? nationalNetwork
-        : visitorTeamNetwork[0].display_name;
+      const networks = getBroadcastNetworks(broadcasters.tv.broadcaster);
 
       dateText.setContent(
         `${emoji.get('calendar')}  ${format(date, 'YYYY/MM/DD')} ${time.slice(
@@ -236,7 +219,7 @@ const game = async option => {
         `${emoji.get('house')}  ${arena} | ${city}, ${state}`
       );
       networkText.setContent(
-        `${homeTeamNetwork}  ${emoji.get('tv')}  ${visitorTeamNetwork}`
+        `${networks.homeTeam}  ${emoji.get('tv')}  ${networks.visitorTeam}`
       );
       while (true) {
         let gamePlayByPlayData = {};

--- a/src/command/game/index.js
+++ b/src/command/game/index.js
@@ -148,10 +148,9 @@ const game = async option => {
     timeText,
     dateText,
     arenaText,
+    networkText,
     homeTeamScoreText,
-    homeTeamNetworkText,
     visitorTeamScoreText,
-    visitorTeamNetworkText,
     playByPlayBox,
     boxscoreTable,
   } = getBlessed(homeTeam, visitorTeam);
@@ -236,10 +235,8 @@ const game = async option => {
       arenaText.setContent(
         `${emoji.get('house')}  ${arena} | ${city}, ${state}`
       );
-      homeTeamNetworkText.setContent(`${homeTeamNetwork}  ${emoji.get('tv')}`);
-      homeTeamNetworkText.position.left = `30%-${homeTeamNetwork.length + 24}`;
-      visitorTeamNetworkText.setContent(
-        `${emoji.get('tv')}  ${visitorTeamNetwork}`
+      networkText.setContent(
+        `${homeTeamNetwork}  ${emoji.get('tv')}  ${visitorTeamNetwork}`
       );
       while (true) {
         let gamePlayByPlayData = {};

--- a/src/command/game/index.js
+++ b/src/command/game/index.js
@@ -152,7 +152,9 @@ const game = async option => {
     dateText,
     arenaText,
     homeTeamScoreText,
+    homeTeamBroadcastText,
     visitorTeamScoreText,
+    visitorTeamBroadcastText,
     playByPlayBox,
     boxscoreTable,
   } = getBlessed(homeTeam, visitorTeam);
@@ -206,7 +208,28 @@ const game = async option => {
       seasonText.setContent(
         bold(`${seasonMetaData.display_year} ${seasonMetaData.display_season}`)
       );
-      const { arena, city, state, date, time } = gameBoxScoreData;
+      const { arena, city, state, date, time, broadcasters } = gameBoxScoreData;
+
+      const broadcastersTV = broadcasters.tv.broadcaster;
+      let homeTeamBroadcast = broadcastersTV.filter(
+        broadcaster => broadcaster.home_visitor === 'home'
+      );
+      let visitorTeamBroadcast = broadcastersTV.filter(
+        broadcaster => broadcaster.home_visitor === 'visitor'
+      );
+      let nationalBroadcast = broadcastersTV.filter(
+        broadcaster => broadcaster.home_visitor === 'natl'
+      );
+      nationalBroadcast = !nationalBroadcast.length
+        ? 'N/A'
+        : nationalBroadcast[0].display_name;
+      homeTeamBroadcast = !homeTeamBroadcast.length
+        ? nationalBroadcast
+        : homeTeamBroadcast[0].display_name;
+      visitorTeamBroadcast = !visitorTeamBroadcast.length
+        ? nationalBroadcast
+        : visitorTeamBroadcast[0].display_name;
+
       dateText.setContent(
         `${emoji.get('calendar')}  ${format(date, 'YYYY/MM/DD')} ${time.slice(
           0,
@@ -216,7 +239,14 @@ const game = async option => {
       arenaText.setContent(
         `${emoji.get('house')}  ${arena} | ${city}, ${state}`
       );
-
+      homeTeamBroadcastText.setContent(
+        `${homeTeamBroadcast}  ${emoji.get('tv')}`
+      );
+      homeTeamBroadcastText.position.left = `30%-${homeTeamBroadcast.length +
+        24}`;
+      visitorTeamBroadcastText.setContent(
+        `${emoji.get('tv')}  ${visitorTeamBroadcast}`
+      );
       while (true) {
         let gamePlayByPlayData = {};
 

--- a/src/command/game/network.js
+++ b/src/command/game/network.js
@@ -1,22 +1,22 @@
+import R from 'ramda';
+
 const getBroadcastNetworks = televisionNetworks => {
-  let homeTeamNetwork = televisionNetworks.filter(
-    broadcaster => broadcaster.home_visitor === 'home'
+  let homeTeamNetwork = R.find(R.propEq('home_visitor', 'home'))(
+    televisionNetworks
   );
-  let visitorTeamNetwork = televisionNetworks.filter(
-    broadcaster => broadcaster.home_visitor === 'visitor'
+  let visitorTeamNetwork = R.find(R.propEq('home_visitor', 'visitor'))(
+    televisionNetworks
   );
-  let nationalNetwork = televisionNetworks.filter(
-    broadcaster => broadcaster.home_visitor === 'natl'
+  let nationalNetwork = R.find(R.propEq('home_visitor', 'natl'))(
+    televisionNetworks
   );
-  nationalNetwork = !nationalNetwork.length
-    ? 'N/A'
-    : nationalNetwork[0].display_name;
-  homeTeamNetwork = !homeTeamNetwork.length
+  nationalNetwork = !nationalNetwork ? 'N/A' : nationalNetwork.display_name;
+  homeTeamNetwork = !homeTeamNetwork
     ? nationalNetwork
-    : homeTeamNetwork[0].display_name;
-  visitorTeamNetwork = !visitorTeamNetwork.length
+    : homeTeamNetwork.display_name;
+  visitorTeamNetwork = !visitorTeamNetwork
     ? nationalNetwork
-    : visitorTeamNetwork[0].display_name;
+    : visitorTeamNetwork.display_name;
 
   return {
     homeTeam: homeTeamNetwork,

--- a/src/command/game/network.js
+++ b/src/command/game/network.js
@@ -1,0 +1,27 @@
+const getBroadcastNetworks = televisionNetworks => {
+  let homeTeamNetwork = televisionNetworks.filter(
+    broadcaster => broadcaster.home_visitor === 'home'
+  );
+  let visitorTeamNetwork = televisionNetworks.filter(
+    broadcaster => broadcaster.home_visitor === 'visitor'
+  );
+  let nationalNetwork = televisionNetworks.filter(
+    broadcaster => broadcaster.home_visitor === 'natl'
+  );
+  nationalNetwork = !nationalNetwork.length
+    ? 'N/A'
+    : nationalNetwork[0].display_name;
+  homeTeamNetwork = !homeTeamNetwork.length
+    ? nationalNetwork
+    : homeTeamNetwork[0].display_name;
+  visitorTeamNetwork = !visitorTeamNetwork.length
+    ? nationalNetwork
+    : visitorTeamNetwork[0].display_name;
+
+  return {
+    homeTeam: homeTeamNetwork,
+    visitorTeam: visitorTeamNetwork,
+  };
+};
+
+export default getBroadcastNetworks;

--- a/src/command/game/preview.js
+++ b/src/command/game/preview.js
@@ -64,6 +64,7 @@ const preview = (
     state,
     display_year,
     display_season,
+    broadcasters,
     homeTeamDashboardData,
     visitorTeamDashboardData,
   }
@@ -96,6 +97,16 @@ const preview = (
       {
         colSpan: 16,
         content: bold(`${emoji.get('house')}  ${arena} ｜ ${city}, ${state}`),
+      },
+    ]),
+    alignCenter([
+      {
+        colSpan: 16,
+        content: bold(
+          `${broadcasters.tv.broadcaster[0].display_name} ${emoji.get('tv')}  ${
+            broadcasters.tv.broadcaster[1].display_name
+          }`
+        ),
       },
     ]),
     alignCenter(

--- a/src/command/game/preview.js
+++ b/src/command/game/preview.js
@@ -2,6 +2,8 @@ import format from 'date-fns/format';
 import { center } from 'wide-align';
 import emoji from 'node-emoji';
 
+import getBroadcastNetworks from './network';
+
 import { bold } from '../../utils/log';
 import { basicTable } from '../../utils/table';
 
@@ -74,6 +76,7 @@ const preview = (
     homeTeam.getFullName({ color: false }).length,
     visitorTeam.getFullName({ color: false }).length
   );
+  const networks = getBroadcastNetworks(broadcasters.tv.broadcaster);
 
   gamePreviewTable.push(
     alignCenter([
@@ -103,9 +106,7 @@ const preview = (
       {
         colSpan: 16,
         content: bold(
-          `${broadcasters.tv.broadcaster[0].display_name} ${emoji.get('tv')}  ${
-            broadcasters.tv.broadcaster[1].display_name
-          }`
+          `${networks.homeTeam} ${emoji.get('tv')}  ${networks.visitorTeam}`
         ),
       },
     ]),

--- a/src/command/game/schedule.js
+++ b/src/command/game/schedule.js
@@ -71,19 +71,16 @@ const createGameChoice = (homeTeam, visitorTeam, periodTime, broadcasters) => {
     nationalNetwork = !nationalNetwork.length
       ? 'N/A'
       : nationalNetwork[0].display_name;
-    homeTeamNetwork = padHomeTeamNetwork(
-      !homeTeamNetwork.length
-        ? nationalNetwork
-        : homeTeamNetwork[0].display_name
-    );
-    visitorTeamNetwork = padAwayTeamNetwork(
-      !visitorTeamNetwork.length
-        ? nationalNetwork
-        : visitorTeamNetwork[0].display_name
-    );
-    const networks = `${homeTeamNetwork} ${emoji.get('tv')}  ${
-      visitorTeamNetwork
-    }|`;
+    homeTeamNetwork = !homeTeamNetwork.length
+      ? nationalNetwork
+      : homeTeamNetwork[0].display_name;
+    visitorTeamNetwork = !visitorTeamNetwork.length
+      ? nationalNetwork
+      : visitorTeamNetwork[0].display_name;
+
+    const networks = `${padHomeTeamNetwork(homeTeamNetwork)} ${emoji.get(
+      'tv'
+    )}  ${padAwayTeamNetwork(visitorTeamNetwork)}|`;
     return `│⌘${match}│${score}│${padGameStatus(
       `${bold(periodStatus)} ${gameClock}`
     )}│${networks}`;

--- a/src/command/game/schedule.js
+++ b/src/command/game/schedule.js
@@ -13,16 +13,14 @@ import { bold, neonGreen } from '../../utils/log';
 const MAX_WIDTH = 81;
 const TEAMNAME_WIDTH = 20;
 const STATUS_WIDTH = 18;
-const BROADCASTER_WIDTH = 35;
-const MAX_WIDTH_WITH_BROADCAST = 156;
+const NETWORK_WIDTH = 35;
+const MAX_WIDTH_WITH_NETWORKS = 156;
 
 const padHomeTeamName = name => bold(right(name, TEAMNAME_WIDTH));
 const padVisitorTeamName = name => bold(left(name, TEAMNAME_WIDTH));
 const padGameStatus = status => center(status, STATUS_WIDTH);
-const padHomeTeamBroadcast = broadcaster =>
-  bold(right(broadcaster, BROADCASTER_WIDTH));
-const padAwayTeamBroadcast = broadcaster =>
-  bold(left(broadcaster, BROADCASTER_WIDTH));
+const padHomeTeamNetwork = network => bold(right(network, NETWORK_WIDTH));
+const padAwayTeamNetwork = network => bold(left(network, NETWORK_WIDTH));
 
 const createGameChoice = (homeTeam, visitorTeam, periodTime, broadcasters) => {
   let winner = '';
@@ -60,35 +58,35 @@ const createGameChoice = (homeTeam, visitorTeam, periodTime, broadcasters) => {
   const score = `${homeTeamScore} : ${visitorTeamScore}`;
 
   if (broadcasters) {
-    const broadcastersTV = broadcasters.tv.broadcaster;
-    let homeTeamBroadcast = broadcastersTV.filter(
+    const televisionNetworks = broadcasters.tv.broadcaster;
+    let homeTeamNetwork = televisionNetworks.filter(
       broadcaster => broadcaster.home_visitor === 'home'
     );
-    let visitorTeamBroadcast = broadcastersTV.filter(
+    let visitorTeamNetwork = televisionNetworks.filter(
       broadcaster => broadcaster.home_visitor === 'visitor'
     );
-    let nationalBroadcast = broadcastersTV.filter(
+    let nationalNetwork = televisionNetworks.filter(
       broadcaster => broadcaster.home_visitor === 'natl'
     );
-    nationalBroadcast = !nationalBroadcast.length
+    nationalNetwork = !nationalNetwork.length
       ? 'N/A'
-      : nationalBroadcast[0].display_name;
-    homeTeamBroadcast = padHomeTeamBroadcast(
-      !homeTeamBroadcast.length
-        ? nationalBroadcast
-        : homeTeamBroadcast[0].display_name
+      : nationalNetwork[0].display_name;
+    homeTeamNetwork = padHomeTeamNetwork(
+      !homeTeamNetwork.length
+        ? nationalNetwork
+        : homeTeamNetwork[0].display_name
     );
-    visitorTeamBroadcast = padAwayTeamBroadcast(
-      !visitorTeamBroadcast.length
-        ? nationalBroadcast
-        : visitorTeamBroadcast[0].display_name
+    visitorTeamNetwork = padAwayTeamNetwork(
+      !visitorTeamNetwork.length
+        ? nationalNetwork
+        : visitorTeamNetwork[0].display_name
     );
-    const broadcast = `${homeTeamBroadcast} ${emoji.get('tv')}  ${
-      visitorTeamBroadcast
+    const networks = `${homeTeamNetwork} ${emoji.get('tv')}  ${
+      visitorTeamNetwork
     }|`;
     return `│⌘${match}│${score}│${padGameStatus(
       `${bold(periodStatus)} ${gameClock}`
-    )}│${broadcast}`;
+    )}│${networks}`;
   }
   return `│⌘${match}│${score}│${padGameStatus(
     `${bold(periodStatus)} ${gameClock}`
@@ -111,19 +109,20 @@ const getTeamInfo = async (team, seasonId) => {
 
 const chooseGameFromSchedule = async (gamesData, option) => {
   const spinner = ora('Loading Game Schedule').start();
-  let broadcastHeader = '';
-  if (option.broadcasts) {
-    broadcastHeader = `${padHomeTeamBroadcast('Home')} ${emoji.get(
+  let networksHeader = '';
+  if (option.networks) {
+    networksHeader = `${padHomeTeamNetwork('Home')} ${emoji.get(
       'tv'
-    )}  ${padAwayTeamBroadcast('Away')}|`;
+    )}  ${padAwayTeamNetwork('Away')}|`;
   }
   const header = `│ ${padHomeTeamName('Home')}${center(
     emoji.get('basketball'),
     8
   )}${padVisitorTeamName('Away')}│${center('Score', 11)}│${padGameStatus(
     'Status'
-  )}│${broadcastHeader}`;
+  )}│${networksHeader}`;
 
+  const tableWidth = !option.networks ? MAX_WIDTH : MAX_WIDTH_WITH_NETWORKS;
   const questions = [
     {
       name: 'game',
@@ -131,19 +130,9 @@ const chooseGameFromSchedule = async (gamesData, option) => {
       type: 'list',
       pageSize: 30,
       choices: [
-        new inquirer.Separator(`
-          ${limit(
-            '',
-            !option.broadcasts ? MAX_WIDTH : MAX_WIDTH_WITH_BROADCAST,
-            '─'
-          )}`),
+        new inquirer.Separator(`${limit('', tableWidth, '─')}`),
         new inquirer.Separator(header),
-        new inquirer.Separator(`
-          ${limit(
-            '',
-            !option.broadcasts ? MAX_WIDTH : MAX_WIDTH_WITH_BROADCAST,
-            '─'
-          )}`),
+        new inquirer.Separator(`${limit('', tableWidth, '─')}`),
       ],
     },
   ];
@@ -162,30 +151,18 @@ const chooseGameFromSchedule = async (gamesData, option) => {
           homeTeam,
           visitorTeam,
           period_time,
-          !option.broadcasts ? null : broadcasters
+          !option.networks ? null : broadcasters
         ),
         value: { gameData, homeTeam, visitorTeam },
       });
 
       if (index !== last) {
         questions[0].choices.push(
-          new inquirer.Separator(
-            `${limit(
-              '',
-              !option.broadcasts ? MAX_WIDTH : MAX_WIDTH_WITH_BROADCAST,
-              '-'
-            )}`
-          )
+          new inquirer.Separator(`${limit('', tableWidth, '─')}`)
         );
       } else {
         questions[0].choices.push(
-          new inquirer.Separator(
-            `${limit(
-              '',
-              !option.broadcasts ? MAX_WIDTH : MAX_WIDTH_WITH_BROADCAST,
-              '-'
-            )}`
-          )
+          new inquirer.Separator(`${limit('', tableWidth, '─')}`)
         );
       }
     },

--- a/src/command/game/schedule.js
+++ b/src/command/game/schedule.js
@@ -5,6 +5,7 @@ import { center, left, right } from 'wide-align';
 import pMap from 'p-map';
 import ora from 'ora';
 
+import getBroadcastNetworks from './network';
 import Team from '../Team';
 
 import NBA from '../../utils/nba';
@@ -58,32 +59,13 @@ const createGameChoice = (homeTeam, visitorTeam, periodTime, broadcasters) => {
   const score = `${homeTeamScore} : ${visitorTeamScore}`;
 
   if (broadcasters) {
-    const televisionNetworks = broadcasters.tv.broadcaster;
-    let homeTeamNetwork = televisionNetworks.filter(
-      broadcaster => broadcaster.home_visitor === 'home'
-    );
-    let visitorTeamNetwork = televisionNetworks.filter(
-      broadcaster => broadcaster.home_visitor === 'visitor'
-    );
-    let nationalNetwork = televisionNetworks.filter(
-      broadcaster => broadcaster.home_visitor === 'natl'
-    );
-    nationalNetwork = !nationalNetwork.length
-      ? 'N/A'
-      : nationalNetwork[0].display_name;
-    homeTeamNetwork = !homeTeamNetwork.length
-      ? nationalNetwork
-      : homeTeamNetwork[0].display_name;
-    visitorTeamNetwork = !visitorTeamNetwork.length
-      ? nationalNetwork
-      : visitorTeamNetwork[0].display_name;
-
-    const networks = `${padHomeTeamNetwork(homeTeamNetwork)} ${emoji.get(
-      'tv'
-    )}  ${padAwayTeamNetwork(visitorTeamNetwork)}|`;
+    const networks = getBroadcastNetworks(broadcasters.tv.broadcaster);
+    const networksOutput = `${padHomeTeamNetwork(
+      networks.homeTeam
+    )} ${emoji.get('tv')}  ${padAwayTeamNetwork(networks.visitorTeam)}|`;
     return `│⌘${match}│${score}│${padGameStatus(
       `${bold(periodStatus)} ${gameClock}`
-    )}│${networks}`;
+    )}│${networksOutput}`;
   }
   return `│⌘${match}│${score}│${padGameStatus(
     `${bold(periodStatus)} ${gameClock}`

--- a/src/command/game/schedule.js
+++ b/src/command/game/schedule.js
@@ -65,11 +65,21 @@ const createGameChoice = (homeTeam, visitorTeam, periodTime, broadcasters) => {
   let visitorTeamBroadcast = broadcastersTV.filter(
     broadcaster => broadcaster.home_visitor === 'visitor'
   );
+  let nationalBroadcast = broadcastersTV.filter(
+    broadcaster => broadcaster.home_visitor === 'natl'
+  );
+  nationalBroadcast = !nationalBroadcast.length
+    ? 'N/A'
+    : nationalBroadcast[0].display_name;
   homeTeamBroadcast = padHomeTeamBroadcast(
-    !homeTeamBroadcast.length ? 'N/A' : homeTeamBroadcast[0].display_name
+    !homeTeamBroadcast.length
+      ? nationalBroadcast
+      : homeTeamBroadcast[0].display_name
   );
   visitorTeamBroadcast = padAwayTeamBroadcast(
-    !visitorTeamBroadcast.length ? 'N/A' : visitorTeamBroadcast[0].display_name
+    !visitorTeamBroadcast.length
+      ? nationalBroadcast
+      : visitorTeamBroadcast[0].display_name
   );
   const broadcast = `${homeTeamBroadcast} ${emoji.get('tv')}  ${
     visitorTeamBroadcast

--- a/src/command/game/scoreboard.js
+++ b/src/command/game/scoreboard.js
@@ -57,7 +57,7 @@ const teamGameLeaders = (homeTeam, visitorTeam, field) =>
 const scoreboard = (
   homeTeam,
   visitorTeam,
-  { date, time, arena, city, state, display_year, display_season }
+  { date, time, arena, city, state, display_year, display_season, broadcasters }
 ) => {
   const scoreboardTable = basicTable();
 
@@ -65,6 +65,26 @@ const scoreboard = (
 
   const homeTeamStartingPlayers = getStartingPlayers(homeTeam);
   const visitorTeamStartingPlayers = getStartingPlayers(visitorTeam);
+
+  const broadcastersTV = broadcasters.tv.broadcaster;
+  let homeTeamBroadcast = broadcastersTV.filter(
+    broadcaster => broadcaster.home_visitor === 'home'
+  );
+  let visitorTeamBroadcast = broadcastersTV.filter(
+    broadcaster => broadcaster.home_visitor === 'visitor'
+  );
+  let nationalBroadcast = broadcastersTV.filter(
+    broadcaster => broadcaster.home_visitor === 'natl'
+  );
+  nationalBroadcast = !nationalBroadcast.length
+    ? 'N/A'
+    : nationalBroadcast[0].display_name;
+  homeTeamBroadcast = !homeTeamBroadcast.length
+    ? nationalBroadcast
+    : homeTeamBroadcast[0].display_name;
+  visitorTeamBroadcast = !visitorTeamBroadcast.length
+    ? nationalBroadcast
+    : visitorTeamBroadcast[0].display_name;
 
   scoreboardTable.push(
     vAlignCenter([
@@ -224,7 +244,15 @@ const scoreboard = (
         hAlign: 'left',
       },
     ]),
-    [],
+    vAlignCenter([
+      {
+        colSpan: 10,
+        content: bold(
+          `${homeTeamBroadcast}a ${emoji.get('tv')}  ${visitorTeamBroadcast}`
+        ),
+        hAlign: 'center',
+      },
+    ]),
     vAlignCenter([
       {
         colSpan: 10,

--- a/src/command/game/scoreboard.js
+++ b/src/command/game/scoreboard.js
@@ -2,6 +2,8 @@ import format from 'date-fns/format';
 import emoji from 'node-emoji';
 import { center } from 'wide-align';
 
+import getBroadcastNetworks from './network';
+
 import { bold, nbaRed, neonGreen } from '../../utils/log';
 import { basicTable } from '../../utils/table';
 
@@ -66,25 +68,7 @@ const scoreboard = (
   const homeTeamStartingPlayers = getStartingPlayers(homeTeam);
   const visitorTeamStartingPlayers = getStartingPlayers(visitorTeam);
 
-  const televisionNetworks = broadcasters.tv.broadcaster;
-  let homeTeamNetwork = televisionNetworks.filter(
-    broadcaster => broadcaster.home_visitor === 'home'
-  );
-  let visitorTeamNetwork = televisionNetworks.filter(
-    broadcaster => broadcaster.home_visitor === 'visitor'
-  );
-  let nationalNetwork = televisionNetworks.filter(
-    broadcaster => broadcaster.home_visitor === 'natl'
-  );
-  nationalNetwork = !nationalNetwork.length
-    ? 'N/A'
-    : nationalNetwork[0].display_name;
-  homeTeamNetwork = !homeTeamNetwork.length
-    ? nationalNetwork
-    : homeTeamNetwork[0].display_name;
-  visitorTeamNetwork = !visitorTeamNetwork.length
-    ? nationalNetwork
-    : visitorTeamNetwork[0].display_name;
+  const networks = getBroadcastNetworks(broadcasters.tv.broadcaster);
 
   scoreboardTable.push(
     vAlignCenter([
@@ -248,7 +232,7 @@ const scoreboard = (
       {
         colSpan: 10,
         content: bold(
-          `${homeTeamNetwork} ${emoji.get('tv')}  ${visitorTeamNetwork}`
+          `${networks.homeTeam} ${emoji.get('tv')}  ${networks.visitorTeam}`
         ),
         hAlign: 'center',
       },

--- a/src/command/game/scoreboard.js
+++ b/src/command/game/scoreboard.js
@@ -66,25 +66,25 @@ const scoreboard = (
   const homeTeamStartingPlayers = getStartingPlayers(homeTeam);
   const visitorTeamStartingPlayers = getStartingPlayers(visitorTeam);
 
-  const broadcastersTV = broadcasters.tv.broadcaster;
-  let homeTeamBroadcast = broadcastersTV.filter(
+  const televisionNetworks = broadcasters.tv.broadcaster;
+  let homeTeamNetwork = televisionNetworks.filter(
     broadcaster => broadcaster.home_visitor === 'home'
   );
-  let visitorTeamBroadcast = broadcastersTV.filter(
+  let visitorTeamNetwork = televisionNetworks.filter(
     broadcaster => broadcaster.home_visitor === 'visitor'
   );
-  let nationalBroadcast = broadcastersTV.filter(
+  let nationalNetwork = televisionNetworks.filter(
     broadcaster => broadcaster.home_visitor === 'natl'
   );
-  nationalBroadcast = !nationalBroadcast.length
+  nationalNetwork = !nationalNetwork.length
     ? 'N/A'
-    : nationalBroadcast[0].display_name;
-  homeTeamBroadcast = !homeTeamBroadcast.length
-    ? nationalBroadcast
-    : homeTeamBroadcast[0].display_name;
-  visitorTeamBroadcast = !visitorTeamBroadcast.length
-    ? nationalBroadcast
-    : visitorTeamBroadcast[0].display_name;
+    : nationalNetwork[0].display_name;
+  homeTeamNetwork = !homeTeamNetwork.length
+    ? nationalNetwork
+    : homeTeamNetwork[0].display_name;
+  visitorTeamNetwork = !visitorTeamNetwork.length
+    ? nationalNetwork
+    : visitorTeamNetwork[0].display_name;
 
   scoreboardTable.push(
     vAlignCenter([
@@ -248,7 +248,7 @@ const scoreboard = (
       {
         colSpan: 10,
         content: bold(
-          `${homeTeamBroadcast} ${emoji.get('tv')}  ${visitorTeamBroadcast}`
+          `${homeTeamNetwork} ${emoji.get('tv')}  ${visitorTeamNetwork}`
         ),
         hAlign: 'center',
       },

--- a/src/command/game/scoreboard.js
+++ b/src/command/game/scoreboard.js
@@ -248,7 +248,7 @@ const scoreboard = (
       {
         colSpan: 10,
         content: bold(
-          `${homeTeamBroadcast}a ${emoji.get('tv')}  ${visitorTeamBroadcast}`
+          `${homeTeamBroadcast} ${emoji.get('tv')}  ${visitorTeamBroadcast}`
         ),
         hAlign: 'center',
       },

--- a/src/utils/__tests__/blessed.spec.js
+++ b/src/utils/__tests__/blessed.spec.js
@@ -44,21 +44,21 @@ describe('getBlessed', () => {
       expect(blessed.screen.mock.calls.length).toBe(1);
     });
 
-    it('should append 13 components and 1 key event', () => {
+    it('should append 15 components and 1 key event', () => {
       const { screen } = getBlessed(mockTeam(), mockTeam());
 
-      expect(screen.append.mock.calls.length).toBe(14);
+      expect(screen.append.mock.calls.length).toBe(15);
       expect(screen.key.mock.calls.length).toBe(1);
     });
   });
 
   describe('others', () => {
-    it('should call blessed.box twice, blessed.table twice, blessed.text 7 times and blessed.bigtext twice', () => {
+    it('should call blessed.box twice, blessed.table twice, blessed.text 9 times and blessed.bigtext twice', () => {
       getBlessed(mockTeam(), mockTeam());
 
       expect(blessed.box.mock.calls.length).toBe(2);
       expect(blessed.table.mock.calls.length).toBe(2);
-      expect(blessed.text.mock.calls.length).toBe(8);
+      expect(blessed.text.mock.calls.length).toBe(9);
       expect(blessed.bigtext.mock.calls.length).toBe(2);
     });
 

--- a/src/utils/blessed.js
+++ b/src/utils/blessed.js
@@ -69,15 +69,6 @@ const getBlessed = (homeTeam, visitorTeam) => {
     },
   });
 
-  const homeTeamNetworkText = blessed.text({
-    top: 9,
-    width: 40,
-    align: 'right',
-    style: {
-      fg: 'white',
-    },
-  });
-
   const homeTeamScoreText = blessed.bigtext({
     font: path.join(__dirname, './fonts/ter-u12n.json'),
     fontBold: path.join(__dirname, './fonts/ter-u12b.json'),
@@ -111,16 +102,6 @@ const getBlessed = (homeTeam, visitorTeam) => {
     width: 15,
     align: 'left',
     content: `(${visitorTeam.getWins()} - ${visitorTeam.getLoses()}) AWAY`,
-    style: {
-      fg: '#fbfbfb',
-    },
-  });
-
-  const visitorTeamNetworkText = blessed.text({
-    top: 9,
-    left: '66%+28',
-    width: 40,
-    align: 'left',
     style: {
       fg: '#fbfbfb',
     },
@@ -167,6 +148,15 @@ const getBlessed = (homeTeam, visitorTeam) => {
 
   const arenaText = blessed.text({
     top: 3,
+    left: 'center',
+    align: 'center',
+    style: {
+      fg: 'white',
+    },
+  });
+
+  const networkText = blessed.text({
+    top: 4,
     left: 'center',
     align: 'center',
     style: {
@@ -225,13 +215,12 @@ const getBlessed = (homeTeam, visitorTeam) => {
   screen.append(timeText);
   screen.append(dateText);
   screen.append(arenaText);
+  screen.append(networkText);
   screen.append(homeTeamFullNameText);
   screen.append(homeTeamStandingsText);
-  screen.append(homeTeamNetworkText);
   screen.append(homeTeamScoreText);
   screen.append(visitorTeamFullNameText);
   screen.append(visitorTeamStandingsText);
-  screen.append(visitorTeamNetworkText);
   screen.append(visitorTeamScoreText);
   screen.append(scoreboardTable);
   screen.append(playByPlayBox);
@@ -245,10 +234,9 @@ const getBlessed = (homeTeam, visitorTeam) => {
     timeText,
     dateText,
     arenaText,
+    networkText,
     homeTeamScoreText,
-    homeTeamNetworkText,
     visitorTeamScoreText,
-    visitorTeamNetworkText,
     playByPlayBox,
     boxscoreTable,
   };

--- a/src/utils/blessed.js
+++ b/src/utils/blessed.js
@@ -69,7 +69,7 @@ const getBlessed = (homeTeam, visitorTeam) => {
     },
   });
 
-  const homeTeamBroadcastText = blessed.text({
+  const homeTeamNetworkText = blessed.text({
     top: 9,
     width: 40,
     align: 'right',
@@ -116,7 +116,7 @@ const getBlessed = (homeTeam, visitorTeam) => {
     },
   });
 
-  const visitorTeamBroadcastText = blessed.text({
+  const visitorTeamNetworkText = blessed.text({
     top: 9,
     left: '66%+28',
     width: 40,
@@ -227,11 +227,11 @@ const getBlessed = (homeTeam, visitorTeam) => {
   screen.append(arenaText);
   screen.append(homeTeamFullNameText);
   screen.append(homeTeamStandingsText);
-  screen.append(homeTeamBroadcastText);
+  screen.append(homeTeamNetworkText);
   screen.append(homeTeamScoreText);
   screen.append(visitorTeamFullNameText);
   screen.append(visitorTeamStandingsText);
-  screen.append(visitorTeamBroadcastText);
+  screen.append(visitorTeamNetworkText);
   screen.append(visitorTeamScoreText);
   screen.append(scoreboardTable);
   screen.append(playByPlayBox);
@@ -246,9 +246,9 @@ const getBlessed = (homeTeam, visitorTeam) => {
     dateText,
     arenaText,
     homeTeamScoreText,
-    homeTeamBroadcastText,
+    homeTeamNetworkText,
     visitorTeamScoreText,
-    visitorTeamBroadcastText,
+    visitorTeamNetworkText,
     playByPlayBox,
     boxscoreTable,
   };

--- a/src/utils/blessed.js
+++ b/src/utils/blessed.js
@@ -69,6 +69,15 @@ const getBlessed = (homeTeam, visitorTeam) => {
     },
   });
 
+  const homeTeamBroadcastText = blessed.text({
+    top: 9,
+    width: 40,
+    align: 'right',
+    style: {
+      fg: 'white',
+    },
+  });
+
   const homeTeamScoreText = blessed.bigtext({
     font: path.join(__dirname, './fonts/ter-u12n.json'),
     fontBold: path.join(__dirname, './fonts/ter-u12b.json'),
@@ -102,6 +111,16 @@ const getBlessed = (homeTeam, visitorTeam) => {
     width: 15,
     align: 'left',
     content: `(${visitorTeam.getWins()} - ${visitorTeam.getLoses()}) AWAY`,
+    style: {
+      fg: '#fbfbfb',
+    },
+  });
+
+  const visitorTeamBroadcastText = blessed.text({
+    top: 9,
+    left: '66%+28',
+    width: 40,
+    align: 'left',
     style: {
       fg: '#fbfbfb',
     },
@@ -208,9 +227,11 @@ const getBlessed = (homeTeam, visitorTeam) => {
   screen.append(arenaText);
   screen.append(homeTeamFullNameText);
   screen.append(homeTeamStandingsText);
+  screen.append(homeTeamBroadcastText);
   screen.append(homeTeamScoreText);
   screen.append(visitorTeamFullNameText);
   screen.append(visitorTeamStandingsText);
+  screen.append(visitorTeamBroadcastText);
   screen.append(visitorTeamScoreText);
   screen.append(scoreboardTable);
   screen.append(playByPlayBox);
@@ -225,7 +246,9 @@ const getBlessed = (homeTeam, visitorTeam) => {
     dateText,
     arenaText,
     homeTeamScoreText,
+    homeTeamBroadcastText,
     visitorTeamScoreText,
+    visitorTeamBroadcastText,
     playByPlayBox,
     boxscoreTable,
   };


### PR DESCRIPTION
We discussed most changes in the issue but below is just a summary of changes. If there is anything you see that you don't like or would like changed just let me know and I'll gladly check it out. I'm 100% open to and welcome code critique as well, always trying to learn. I'm newer to javascript and did my best to keep all existing code in place and as clean as possible. Appreciate the opportunity to work on this.

- **Game Schedule** will show broadcast network information when the new command line options `-n or --networks` are used
    - Required a few changes to how the table is drawn
- **Game Preview** will always show broadcast network information below arena information
- **Game Live** will always shows broadcast information below arena information
- **Game Final** will always shows broadcast information below arena information
- Added `network.js` file to store getBroadcastNetworks function
    - Contains the logic for determining home/away broadcast network and if national should be used (if there is no home or away network it checks for national and if no national then sets value to ’N/A’)
- Added some tests
- Updated README to include `-n/—networks` command
    - I did not create a screencast to demo it