### PR TITLE
Added --compare option to compare multiple players

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,6 @@ When listing the multiple names they must be in quotes and seperated by commas. 
 ```
 $ nba-go player "Lebron James, Stephen Curry, James Harden" -c -i -r -p
 ```
-![player -c gif](https://user-images.githubusercontent.com/36014115/37246796-0d4a2d26-2465-11e8-89d5-4f7f33b4ef59.gif)
-
 
 #### Mixed them all
 Get all data at the same time.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,16 @@ $ nba-go player Curry -p
 ```
 ![player -p gif](https://user-images.githubusercontent.com/12113222/32500032-234e8fba-c40f-11e7-87c0-6e42a66a52dc.gif)
 
+##### `-c` or `--compare`  
+Get and compare the stats from multiple players. The better stat will be highlighted in green to make comparing easier.
+When listing the multiple names they must be in quotes and seperated by commas. Can be combined with the -i, -r, and -p flags.
+
+```
+$ nba-go player "Lebron James, Stephen Curry, James Harden" -c -i -r -p
+```
+![player -c gif](https://user-images.githubusercontent.com/36014115/37246796-0d4a2d26-2465-11e8-89d5-4f7f33b4ef59.gif)
+
+
 #### Mixed them all
 Get all data at the same time.
 ```

--- a/src/cli.js
+++ b/src/cli.js
@@ -34,6 +34,10 @@ program
   .option('-i, --info', "Check the player's basic information")
   .option('-r, --regular', "Check the player's career regular season data")
   .option('-p, --playoffs', "Check the player's career playoffs data")
+  .option(
+    '-c, --compare',
+    "Compare the stats of two or more players. Seperate the names with commas, ex:'Stepen Curry, Lebron James'"
+  )
   .on('--help', () => {
     console.log('');
     console.log(

--- a/src/command/player/index.js
+++ b/src/command/player/index.js
@@ -10,7 +10,16 @@ import catchAPIError from '../../utils/catchAPIError';
 const player = async (playerName, option) => {
   await NBA.updatePlayers();
 
-  const _players = await NBA.searchPlayers(playerName);
+  // split the input by commas and then find matching players and add to array
+  // works even if only input 1 player
+  const _players = [];
+  const nameArray = playerName.split(',');
+  nameArray.forEach(name => {
+    const playerData = NBA.searchPlayers(name.trim());
+    _players.push(...playerData);
+  });
+
+  // const _players = await NBA.searchPlayers(playerName);
 
   pMap(
     _players,

--- a/src/command/player/index.js
+++ b/src/command/player/index.js
@@ -24,8 +24,6 @@ const player = async (playerName, option) => {
 
   // if we are comparing we need to get all the data first before make the table
   if (option.compare) {
-    // get basic info about all the players in array
-
     // do this a little bit different than the original
     // get all the player data in an array, then will pass to playerInfoCompare and parse it
     const infoMapper = elem => NBA.playerInfo({ PlayerID: elem.playerId });
@@ -40,6 +38,7 @@ const player = async (playerName, option) => {
       playerInfoCompare(playerDataArr);
     }
     if (option.regular || option.playoffs) {
+      // if getting regular season data need to get more data
       const profileMapper = elem =>
         NBA.playerProfile({ PlayerID: elem.playerId });
       let playerProfileArr;
@@ -48,6 +47,7 @@ const player = async (playerName, option) => {
           playerProfileArr = result;
         })
         .catch(err => catchAPIError(err, 'NBA.playerProfile()'));
+
       if (option.regular) {
         seasonStatsCompare(playerProfileArr, playerDataArr, 'Regular Season');
       }
@@ -56,6 +56,7 @@ const player = async (playerName, option) => {
       }
     }
   } else {
+    // if we aren't doing any comparing
     pMap(
       _players,
       async _player => {

--- a/src/command/player/index.js
+++ b/src/command/player/index.js
@@ -13,8 +13,6 @@ import seasonStatsCompare from './seasonStatsCompare';
 const player = async (playerName, option) => {
   await NBA.updatePlayers();
 
-  // split the input by commas and then find matching players and add to array
-  // works even if only input 1 player
   const _players = [];
   const nameArray = playerName.split(',');
   nameArray.forEach(name => {
@@ -22,10 +20,7 @@ const player = async (playerName, option) => {
     _players.push(...playerData);
   });
 
-  // if we are comparing we need to get all the data first before make the table
   if (option.compare) {
-    // do this a little bit different than the original
-    // get all the player data in an array, then will pass to playerInfoCompare and parse it
     const infoMapper = elem => NBA.playerInfo({ PlayerID: elem.playerId });
     let playerDataArr;
     try {
@@ -38,7 +33,6 @@ const player = async (playerName, option) => {
       playerInfoCompare(playerDataArr);
     }
     if (option.regular || option.playoffs) {
-      // if getting regular season data need to get more data
       const profileMapper = elem =>
         NBA.playerProfile({ PlayerID: elem.playerId });
       let playerProfileArr;
@@ -55,7 +49,6 @@ const player = async (playerName, option) => {
       }
     }
   } else {
-    // if we aren't doing any comparing
     pMap(
       _players,
       async _player => {

--- a/src/command/player/index.js
+++ b/src/command/player/index.js
@@ -8,6 +8,7 @@ import playerInfoCompare from './infoCompare';
 
 import NBA from '../../utils/nba';
 import catchAPIError from '../../utils/catchAPIError';
+import seasonStatsCompare from './seasonStatsCompare';
 
 const player = async (playerName, option) => {
   await NBA.updatePlayers();
@@ -24,12 +25,12 @@ const player = async (playerName, option) => {
   // if we are comparing we need to get all the data first before make the table
   if (option.compare) {
     // get basic info about all the players in array
-    const mapper = elem => NBA.playerInfo({ PlayerID: elem.playerId });
 
     // do this a little bit different than the original
     // get all the player data in an array, then will pass to playerInfoCompare and parse it
+    const infoMapper = elem => NBA.playerInfo({ PlayerID: elem.playerId });
     let playerDataArr;
-    await pMap(_players, mapper)
+    await pMap(_players, infoMapper)
       .then(result => {
         playerDataArr = result;
       })
@@ -37,6 +38,17 @@ const player = async (playerName, option) => {
 
     if (option.info) {
       playerInfoCompare(playerDataArr);
+    }
+    if (option.regular) {
+      const profileMapper = elem =>
+        NBA.playerProfile({ PlayerID: elem.playerId });
+      let playerProfileArr;
+      await pMap(_players, profileMapper)
+        .then(result => {
+          playerProfileArr = result;
+        })
+        .catch(err => catchAPIError(err, 'NBA.playerProfile()'));
+      seasonStatsCompare(playerProfileArr, playerDataArr, 'Regular Season');
     }
   } else {
     pMap(

--- a/src/command/player/index.js
+++ b/src/command/player/index.js
@@ -4,6 +4,8 @@ import emoji from 'node-emoji';
 import playerInfo from './info';
 import seasonStats from './seasonStats';
 
+import playerInfoCompare from './infoCompare';
+
 import NBA from '../../utils/nba';
 import catchAPIError from '../../utils/catchAPIError';
 
@@ -19,99 +21,116 @@ const player = async (playerName, option) => {
     _players.push(...playerData);
   });
 
-  // const _players = await NBA.searchPlayers(playerName);
+  // if we are comparing we need to get all the data first before make the table
+  if (option.compare) {
+    // get basic info about all the players in array
+    const mapper = elem => NBA.playerInfo({ PlayerID: elem.playerId });
 
-  pMap(
-    _players,
-    async _player => {
-      let commonPlayerInfo;
-      let playerHeadlineStats;
+    // do this a little bit different than the original
+    // get all the player data in an array, then will pass to playerInfoCompare and parse it
+    let playerDataArr;
+    await pMap(_players, mapper)
+      .then(result => {
+        playerDataArr = result;
+      })
+      .catch(err => catchAPIError(err, 'NBA.playerInfo()'));
 
-      try {
-        const {
-          commonPlayerInfo: _commonPlayerInfo,
-          playerHeadlineStats: _playerHeadlineStats,
-        } = await NBA.playerInfo({
-          PlayerID: _player.playerId,
-        });
-
-        commonPlayerInfo = _commonPlayerInfo;
-        playerHeadlineStats = _playerHeadlineStats;
-      } catch (err) {
-        catchAPIError(err, 'NBA.playerInfo()');
-      }
-
-      if (option.info) {
-        playerInfo({ ...commonPlayerInfo[0], ...playerHeadlineStats[0] });
-      }
-
-      if (option.regular) {
-        let seasonTotalsRegularSeason;
-        let careerTotalsRegularSeason;
+    if (option.info) {
+      playerInfoCompare(playerDataArr);
+    }
+  } else {
+    pMap(
+      _players,
+      async _player => {
+        let commonPlayerInfo;
+        let playerHeadlineStats;
 
         try {
           const {
-            seasonTotalsRegularSeason: _seasonTotalsRegularSeason,
-            careerTotalsRegularSeason: _careerTotalsRegularSeason,
-          } = await NBA.playerProfile({
+            commonPlayerInfo: _commonPlayerInfo,
+            playerHeadlineStats: _playerHeadlineStats,
+          } = await NBA.playerInfo({
             PlayerID: _player.playerId,
           });
 
-          seasonTotalsRegularSeason = _seasonTotalsRegularSeason;
-          careerTotalsRegularSeason = _careerTotalsRegularSeason;
+          commonPlayerInfo = _commonPlayerInfo;
+          playerHeadlineStats = _playerHeadlineStats;
         } catch (err) {
-          catchAPIError(err, 'NBA.playerProfile()');
+          catchAPIError(err, 'NBA.playerInfo()');
         }
 
-        commonPlayerInfo[0].nowTeamAbbreviation =
-          commonPlayerInfo[0].teamAbbreviation;
-
-        seasonStats({
-          seasonTtpe: 'Regular Season',
-          ...commonPlayerInfo[0],
-          seasonTotals: seasonTotalsRegularSeason,
-          careerTotals: careerTotalsRegularSeason[0],
-        });
-      }
-
-      if (option.playoffs) {
-        let seasonTotalsPostSeason;
-        let careerTotalsPostSeason;
-        try {
-          const {
-            seasonTotalsPostSeason: _seasonTotalsPostSeason,
-            careerTotalsPostSeason: _careerTotalsPostSeason,
-          } = await NBA.playerProfile({
-            PlayerID: _player.playerId,
-          });
-
-          seasonTotalsPostSeason = _seasonTotalsPostSeason;
-          careerTotalsPostSeason = _careerTotalsPostSeason;
-        } catch (err) {
-          catchAPIError(err, 'NBA.playerProfile()');
+        if (option.info) {
+          playerInfo({ ...commonPlayerInfo[0], ...playerHeadlineStats[0] });
         }
 
-        if (careerTotalsPostSeason.length === 0) {
-          console.log(
-            `Sorry, ${_player.firstName} ${
-              _player.lastName
-            } doesn't have any playoffs data ${emoji.get('confused')}`
-          );
-        } else {
+        if (option.regular) {
+          let seasonTotalsRegularSeason;
+          let careerTotalsRegularSeason;
+
+          try {
+            const {
+              seasonTotalsRegularSeason: _seasonTotalsRegularSeason,
+              careerTotalsRegularSeason: _careerTotalsRegularSeason,
+            } = await NBA.playerProfile({
+              PlayerID: _player.playerId,
+            });
+
+            seasonTotalsRegularSeason = _seasonTotalsRegularSeason;
+            careerTotalsRegularSeason = _careerTotalsRegularSeason;
+          } catch (err) {
+            catchAPIError(err, 'NBA.playerProfile()');
+          }
+
           commonPlayerInfo[0].nowTeamAbbreviation =
             commonPlayerInfo[0].teamAbbreviation;
 
           seasonStats({
-            seasonTtpe: 'Playoffs',
+            seasonTtpe: 'Regular Season',
             ...commonPlayerInfo[0],
-            seasonTotals: seasonTotalsPostSeason,
-            careerTotals: careerTotalsPostSeason[0],
+            seasonTotals: seasonTotalsRegularSeason,
+            careerTotals: careerTotalsRegularSeason[0],
           });
         }
-      }
-    },
-    { concurrency: 1 }
-  );
+
+        if (option.playoffs) {
+          let seasonTotalsPostSeason;
+          let careerTotalsPostSeason;
+          try {
+            const {
+              seasonTotalsPostSeason: _seasonTotalsPostSeason,
+              careerTotalsPostSeason: _careerTotalsPostSeason,
+            } = await NBA.playerProfile({
+              PlayerID: _player.playerId,
+            });
+
+            seasonTotalsPostSeason = _seasonTotalsPostSeason;
+            careerTotalsPostSeason = _careerTotalsPostSeason;
+          } catch (err) {
+            catchAPIError(err, 'NBA.playerProfile()');
+          }
+
+          if (careerTotalsPostSeason.length === 0) {
+            console.log(
+              `Sorry, ${_player.firstName} ${
+                _player.lastName
+              } doesn't have any playoffs data ${emoji.get('confused')}`
+            );
+          } else {
+            commonPlayerInfo[0].nowTeamAbbreviation =
+              commonPlayerInfo[0].teamAbbreviation;
+
+            seasonStats({
+              seasonTtpe: 'Playoffs',
+              ...commonPlayerInfo[0],
+              seasonTotals: seasonTotalsPostSeason,
+              careerTotals: careerTotalsPostSeason[0],
+            });
+          }
+        }
+      },
+      { concurrency: 1 }
+    );
+  }
 };
 
 export default player;

--- a/src/command/player/index.js
+++ b/src/command/player/index.js
@@ -39,7 +39,7 @@ const player = async (playerName, option) => {
     if (option.info) {
       playerInfoCompare(playerDataArr);
     }
-    if (option.regular) {
+    if (option.regular || option.playoffs) {
       const profileMapper = elem =>
         NBA.playerProfile({ PlayerID: elem.playerId });
       let playerProfileArr;
@@ -48,7 +48,12 @@ const player = async (playerName, option) => {
           playerProfileArr = result;
         })
         .catch(err => catchAPIError(err, 'NBA.playerProfile()'));
-      seasonStatsCompare(playerProfileArr, playerDataArr, 'Regular Season');
+      if (option.regular) {
+        seasonStatsCompare(playerProfileArr, playerDataArr, 'Regular Season');
+      }
+      if (option.playoffs) {
+        seasonStatsCompare(playerProfileArr, playerDataArr, 'Post Season');
+      }
     }
   } else {
     pMap(

--- a/src/command/player/index.js
+++ b/src/command/player/index.js
@@ -28,11 +28,11 @@ const player = async (playerName, option) => {
     // get all the player data in an array, then will pass to playerInfoCompare and parse it
     const infoMapper = elem => NBA.playerInfo({ PlayerID: elem.playerId });
     let playerDataArr;
-    await pMap(_players, infoMapper)
-      .then(result => {
-        playerDataArr = result;
-      })
-      .catch(err => catchAPIError(err, 'NBA.playerInfo()'));
+    try {
+      playerDataArr = await pMap(_players, infoMapper);
+    } catch (err) {
+      catchAPIError(err, 'NBA.playerInfo()');
+    }
 
     if (option.info) {
       playerInfoCompare(playerDataArr);
@@ -42,12 +42,11 @@ const player = async (playerName, option) => {
       const profileMapper = elem =>
         NBA.playerProfile({ PlayerID: elem.playerId });
       let playerProfileArr;
-      await pMap(_players, profileMapper)
-        .then(result => {
-          playerProfileArr = result;
-        })
-        .catch(err => catchAPIError(err, 'NBA.playerProfile()'));
-
+      try {
+        playerProfileArr = await pMap(_players, profileMapper);
+      } catch (err) {
+        catchAPIError(err, 'NBA.playerProfile()');
+      }
       if (option.regular) {
         seasonStatsCompare(playerProfileArr, playerDataArr, 'Regular Season');
       }

--- a/src/command/player/infoCompare.js
+++ b/src/command/player/infoCompare.js
@@ -6,11 +6,18 @@ import { convertToCm, convertToKg } from '../../utils/convertUnit';
 import table from '../../utils/table';
 import { bold } from '../../utils/log';
 
+/*
+Author: DoubleB123, bbrenner321@gmail.com
+This is called by index.js when comparing the stats of players
+It is similar to info.js but a few more steps to 
+compile the data between players for display
+*/
+
 const alignCenter = columns =>
   columns.map(content => ({ content, hAlign: 'center', vAlign: 'center' }));
 
 // in the original info.js it it doesn't have a foreach loop
-// here i loop through each player and create table entries and at the end push to the table
+// here I loop through each player and create table entries and at the end push to the table
 const infoCompare = playerInfo => {
   const playerTable = table.basicTable();
   // these will be the table entries, append to them and then add a new line

--- a/src/command/player/infoCompare.js
+++ b/src/command/player/infoCompare.js
@@ -1,0 +1,104 @@
+import chalk from 'chalk';
+import format from 'date-fns/format';
+import { getMainColor } from 'nba-color';
+
+import { convertToCm, convertToKg } from '../../utils/convertUnit';
+import table from '../../utils/table';
+import { bold } from '../../utils/log';
+
+const alignCenter = columns =>
+  columns.map(content => ({ content, hAlign: 'center', vAlign: 'center' }));
+
+// in the original info.js it it doesn't have a foreach loop
+// here i loop through each player and create table entries and at the end push to the table
+const infoCompare = playerInfo => {
+  const playerTable = table.basicTable();
+  // these will be the table entries, append to them and then add a new line
+  // after the loop push to the table
+  let nameStr = '';
+  let heightStr = '';
+  let weightStr = '';
+  let countryStr = '';
+  let birthStr = '';
+  let seasonStr = '';
+  let draftStr = '';
+  let ptsStr = '';
+  let rebStr = '';
+  let astStr = '';
+
+  playerInfo.forEach(elem => {
+    const {
+      teamAbbreviation,
+      jersey,
+      displayFirstLast,
+      height,
+      weight,
+      country,
+      birthdate,
+      seasonExp,
+      draftYear,
+      draftRound,
+      draftNumber,
+      pts,
+      reb,
+      ast,
+    } = { ...elem.commonPlayerInfo[0], ...elem.playerHeadlineStats[0] };
+
+    const teamMainColor = getMainColor(teamAbbreviation);
+    const playerName = chalk`{bold.white.bgHex('${
+      teamMainColor ? teamMainColor.hex : '#000'
+    }') ${teamAbbreviation}} {bold.white #${jersey} ${displayFirstLast}}`;
+
+    const draft =
+      draftYear !== 'Undrafted'
+        ? `${draftYear} Rnd ${draftRound} Pick ${draftNumber}`
+        : 'Undrafted';
+
+    nameStr += `${playerName}\n`;
+    heightStr += `${height} / ${convertToCm(height)}\n`;
+    weightStr += `${weight} / ${convertToKg(weight)}\n`;
+    countryStr += `${country}\n`;
+    birthStr += `${format(birthdate, 'YYYY/MM/DD')}\n`;
+    seasonStr += `${seasonExp} yrs\n`;
+    draftStr += `${draft}\n`;
+    ptsStr += `${pts}\n`;
+    rebStr += `${reb}\n`;
+    astStr += `${ast}\n`;
+  });
+
+  playerTable.push(
+    [
+      {
+        colSpan: 9,
+        content: nameStr.trim(),
+        hAlign: 'center',
+        vAlign: 'center',
+      },
+    ],
+    alignCenter([
+      bold('Height'),
+      bold('Weight'),
+      bold('Country'),
+      bold('Born'),
+      bold('EXP'),
+      bold('Draft'),
+      bold('PTS'),
+      bold('REB'),
+      bold('AST'),
+    ]),
+    alignCenter([
+      heightStr.trim(),
+      weightStr.trim(),
+      countryStr.trim(),
+      birthStr.trim(),
+      seasonStr.trim(),
+      draftStr.trim(),
+      ptsStr.trim(),
+      rebStr.trim(),
+      astStr.trim(),
+    ])
+  );
+  console.log(playerTable.toString());
+};
+
+export default infoCompare;

--- a/src/command/player/infoCompare.js
+++ b/src/command/player/infoCompare.js
@@ -6,32 +6,12 @@ import { convertToCm, convertToKg } from '../../utils/convertUnit';
 import table from '../../utils/table';
 import { bold } from '../../utils/log';
 
-/*
-Author: DoubleB123, bbrenner321@gmail.com
-This is called by index.js when comparing the stats of players
-It is similar to info.js but a few more steps to 
-compile the data between players for display
-*/
-
 const alignCenter = columns =>
   columns.map(content => ({ content, hAlign: 'center', vAlign: 'center' }));
 
-// in the original info.js it it doesn't have a foreach loop
-// here I loop through each player and create table entries and at the end push to the table
 const infoCompare = playerInfo => {
   const playerTable = table.basicTable();
-  // these will be the table entries, append to them and then add a new line
-  // after the loop push to the table
   let nameStr = '';
-  let heightStr = '';
-  let weightStr = '';
-  let countryStr = '';
-  let birthStr = '';
-  let seasonStr = '';
-  let draftStr = '';
-  let ptsStr = '';
-  let rebStr = '';
-  let astStr = '';
 
   playerInfo.forEach(elem => {
     const {
@@ -62,18 +42,23 @@ const infoCompare = playerInfo => {
         : 'Undrafted';
 
     nameStr += `${playerName}\n`;
-    heightStr += `${height} / ${convertToCm(height)}\n`;
-    weightStr += `${weight} / ${convertToKg(weight)}\n`;
-    countryStr += `${country}\n`;
-    birthStr += `${format(birthdate, 'YYYY/MM/DD')}\n`;
-    seasonStr += `${seasonExp} yrs\n`;
-    draftStr += `${draft}\n`;
-    ptsStr += `${pts}\n`;
-    rebStr += `${reb}\n`;
-    astStr += `${ast}\n`;
+
+    playerTable.push(
+      alignCenter([
+        `${height} / ${convertToCm(height)}`,
+        `${weight} / ${convertToKg(weight)}`,
+        country,
+        `${format(birthdate, 'YYYY/MM/DD')}`,
+        `${seasonExp} yrs`,
+        draft,
+        pts,
+        reb,
+        ast,
+      ])
+    );
   });
 
-  playerTable.push(
+  playerTable.unshift(
     [
       {
         colSpan: 9,
@@ -92,17 +77,6 @@ const infoCompare = playerInfo => {
       bold('PTS'),
       bold('REB'),
       bold('AST'),
-    ]),
-    alignCenter([
-      heightStr.trim(),
-      weightStr.trim(),
-      countryStr.trim(),
-      birthStr.trim(),
-      seasonStr.trim(),
-      draftStr.trim(),
-      ptsStr.trim(),
-      rebStr.trim(),
-      astStr.trim(),
     ])
   );
   console.log(playerTable.toString());

--- a/src/command/player/seasonStatsCompare.js
+++ b/src/command/player/seasonStatsCompare.js
@@ -30,6 +30,7 @@ const makeNameStr = (playerInfo, seasonTtpe) => {
 // each season maps to an array of the player stats for that season
 const makeSeasonObj = (playerProfile, seasonStr) => {
   const seasonObj = {};
+  let index = 0;
   playerProfile.forEach(player => {
     // access the season totals for either post or regular season
     const seasonArr = player[`seasonTotals${seasonStr}`];
@@ -38,12 +39,14 @@ const makeSeasonObj = (playerProfile, seasonStr) => {
       // check if the season is already in the object
       if (seasonObj[currentSeason]) {
         // if it does add this players data to the array
-        seasonObj[currentSeason].push(season);
+        seasonObj[currentSeason][index] = season;
       } else {
-        // otherwise create a new array
-        seasonObj[currentSeason] = [season];
+        // otherwise create a new array with length of number of players
+        seasonObj[currentSeason] = [...Array(playerProfile.length)].fill({});
+        seasonObj[currentSeason][index] = season;
       }
     });
+    ++index;
   });
   return seasonObj;
 };
@@ -67,9 +70,11 @@ const makeRow = seasonData => {
     tov: '',
   };
 
+  let seasonId;
   seasonData.forEach(player => {
     //configure certain data before we append to string
-    if(player !== {}){
+    //make sure object isn't empty
+    if(Object.keys(player).length !== 0){
       player.fg3Pct = (player.fg3Pct * 100).toFixed(1)
       player.fgPct = (player.fgPct * 100).toFixed(1)
       player.ftPct = (player.ftPct * 100).toFixed(1)
@@ -77,14 +82,16 @@ const makeRow = seasonData => {
       player.teamAbbreviation = chalk`{bold.white.bgHex('${
           teamMainColor ? teamMainColor.hex : '#000'
         }') ${player.teamAbbreviation}}`
+      if(!template.seasonId){
+        seasonId = bold(player.seasonId);
+      }
     }
     Object.keys(template).forEach(key =>{
       //add data to str or if no data put in a dash
-      template[key] += (player[key] + '\n') || '-\n';
+      template[key] += (player[key] || '-') + '\n';
     });
   });
-
-  template.seasonId = bold(seasonData[0].seasonId);
+  template.seasonId = seasonId;
   return template;
 };
 
@@ -97,13 +104,10 @@ const seasonStatsCompare = (
   const seasonStr = seasonTtpe.replace(/\s/g, '');
 
   const seasonObj = makeSeasonObj(playerProfile, seasonStr);
-
   const nameStr = makeNameStr(playerInfo, seasonTtpe);
-  //const seasonDataStr = makeSeasonStr(seasonObj);
 
   // use all the strings we generated to make the table
   const seasonTable = table.basicTable();
-
   seasonTable.push([
     { colSpan: 14, content: nameStr.trim(), hAlign: 'center' },
   ]);
@@ -126,30 +130,24 @@ const seasonStatsCompare = (
     ])
   );
 
-  //for each season in seasonObj
-  //row = makeRow
-  //table.push(row)
-  Object.keys(seasonObj).forEach(key => {
-    debugger;
+  Object.keys(seasonObj).reverse().forEach(key => {
     const row = makeRow(seasonObj[key]);
-    debugger;
-  
     seasonTable.push(
       alignCenter([
-        row.seasonId,
-        row.teamAbbreviation,
-        row.playerAge,
-        row.gp,
-        row.min,
-        row.pts,
-        row.fgPct,
-        row.fg3Pct,
-        row.ftPct,
-        row.ast,
-        row.reb,
-        row.stl,
-        row.blk,
-        row.tov,
+        row.seasonId.trim(),
+        row.teamAbbreviation.trim(),
+        row.playerAge.trim(),
+        row.gp.trim(),
+        row.min.trim(),
+        row.pts.trim(),
+        row.fgPct.trim(),
+        row.fg3Pct.trim(),
+        row.ftPct.trim(),
+        row.ast.trim(),
+        row.reb.trim(),
+        row.stl.trim(),
+        row.blk.trim(),
+        row.tov.trim()
       ])
     );
   });

--- a/src/command/player/seasonStatsCompare.js
+++ b/src/command/player/seasonStatsCompare.js
@@ -1,3 +1,4 @@
+import R from 'ramda';
 import chalk from 'chalk';
 import { getMainColor } from 'nba-color';
 
@@ -96,16 +97,18 @@ const makeRow = seasonData => {
         seasonId = bold(player.seasonId);
       }
     }
-    Object.keys(template).forEach(key => {
+    const templatePusher = (val, key) => {
       template[key].push(player[key] || '-');
-    });
+    };
+    R.forEachObjIndexed(templatePusher, template);
   });
 
-  Object.keys(template).forEach(key => {
+  const colorStats = (val, key) => {
     const maxInd = findMaxInd(template[key]);
     template[key][maxInd] = chalk.green(template[key][maxInd]);
     template[key] = template[key].join('\n');
-  });
+  };
+  R.forEachObjIndexed(colorStats, template);
 
   template.seasonId = seasonId;
   return template;
@@ -123,11 +126,12 @@ const seasonStatsCompare = (
   const overallArr = makeOverall(playerProfile, seasonStr);
   const nameStr = makeNameStr(playerInfo, seasonTtpe);
 
-  const seasonDates = Object.keys(seasonObj).sort((a, b) => {
+  const sorter = (a, b) => {
     const adate = a.split('-')[0];
     const bdate = b.split('-')[0];
     return adate - bdate;
-  });
+  };
+  const seasonDates = R.sort(sorter, R.keys(seasonObj));
 
   const seasonTable = table.basicTable();
   seasonTable.push([

--- a/src/command/player/seasonStatsCompare.js
+++ b/src/command/player/seasonStatsCompare.js
@@ -1,3 +1,6 @@
+/* eslint-disable */
+
+
 import chalk from 'chalk';
 import { getMainColor } from 'nba-color';
 
@@ -7,23 +10,86 @@ import table from '../../utils/table';
 const alignCenter = columns =>
   columns.map(content => ({ content, hAlign: 'center', vAlign: 'center' }));
 
-const seasonStatsCompare = ({
-  seasonTtpe,
-  nowTeamAbbreviation,
-  jersey,
-  displayFirstLast,
-  seasonTotals,
-  careerTotals,
-}) => {
-  console.log('comparing');
-  const nowTeamMainColor = getMainColor(nowTeamAbbreviation);
+// takes in the player info array and gets the names and jersey and creates a string containing them all
+const makeNameStr = (playerInfo, seasonTtpe) => {
+  let nameStr = '';
+  playerInfo.forEach(player => {
+    const { teamAbbreviation, jersey, displayFirstLast } = {
+      ...player.commonPlayerInfo[0],
+    };
+    const teamMainColor = getMainColor(teamAbbreviation);
+    const playerName = chalk`{bold.white.bgHex('${
+      teamMainColor ? teamMainColor.hex : '#000'
+    }') ${teamAbbreviation}} {bold.white #${jersey} ${displayFirstLast} │ ${
+      seasonTtpe
+    }}`;
+    nameStr += `${playerName}\n`;
+  });
+  return nameStr;
+};
+
+// takes in the object contining seasons and returns an array where each entry represents a season
+// the entries will be objects where keys map to strings to push to table
+const makeSeasonStr = seasonObj => {
+  const template = {
+    seasonId: '',
+    abbreviaton: '',
+    playerAge: '',
+    gp: '',
+    min: '',
+    pts: '',
+    fpPct: '',
+    fg3Pct: '',
+    ftPct: '',
+    ast: '',
+    reb: '',
+    stl: '',
+    blk: '',
+    tov: '',
+  };
+  /*
+  seasonTable.push(
+    alignCenter([
+      bold(seasonId),
+      chalk`{bold.white.bgHex('${
+        teamMainColor ? teamMainColor.hex : '#000'
+      }') ${teamAbbreviation}}`,
+      playerAge,
+      gp,
+      min,
+      pts,
+      (fgPct * 100).toFixed(1),
+      (fg3Pct * 100).toFixed(1),
+      (ftPct * 100).toFixed(1),
+      ast,
+      reb,
+      stl,
+      blk,
+      tov,
+    ])
+  );
+  */
+};
+
+const seasonStatsCompare = (
+  playerProfile,
+  playerInfo,
+  seasonTtpe = 'Regular Season'
+) => {
+  // these strings are used so we can get the correct data at the beginning and dont have to write same code twice
+  const seasonStr = seasonTtpe.replace(/\s/g, '');
+
+  const seasonObj = makeSeasonTable(playerProfile, seasonStr);
+  const seasonDataStr = makeSeasonStr(seasonObj);
+
+  const nameStr = makeNameStr(playerInfo, seasonTtpe);
+
+  // use all the strings we generated to make the table
   const seasonTable = table.basicTable();
-  const playerName = chalk`{bold.white.bgHex('${
-    nowTeamMainColor ? nowTeamMainColor.hex : '#000'
-  }') ${nowTeamAbbreviation}} {bold.white #${jersey} ${displayFirstLast} │ ${
-    seasonTtpe
-  }}`;
-  seasonTable.push([{ colSpan: 14, content: playerName, hAlign: 'center' }]);
+
+  seasonTable.push([
+    { colSpan: 14, content: nameStr.trim(), hAlign: 'center' },
+  ]);
   seasonTable.push(
     alignCenter([
       bold('SEASON'),
@@ -40,6 +106,30 @@ const seasonStatsCompare = ({
       bold('STL'),
       bold('BLK'),
       bold('TOV'),
+    ])
+  );
+
+  console.log(seasonTable.toString());
+
+  /*
+  seasonTable.push(
+    alignCenter([
+      bold(seasonId),
+      chalk`{bold.white.bgHex('${
+        teamMainColor ? teamMainColor.hex : '#000'
+      }') ${teamAbbreviation}}`,
+      playerAge,
+      gp,
+      min,
+      pts,
+      (fgPct * 100).toFixed(1),
+      (fg3Pct * 100).toFixed(1),
+      (ftPct * 100).toFixed(1),
+      ast,
+      reb,
+      stl,
+      blk,
+      tov,
     ])
   );
 
@@ -61,28 +151,6 @@ const seasonStatsCompare = ({
       tov,
     } = season;
     const teamMainColor = getMainColor(teamAbbreviation);
-
-    seasonTable.push(
-      alignCenter([
-        bold(seasonId),
-        chalk`{bold.white.bgHex('${
-          teamMainColor ? teamMainColor.hex : '#000'
-        }') ${teamAbbreviation}}`,
-        playerAge,
-        gp,
-        min,
-        pts,
-        (fgPct * 100).toFixed(1),
-        (fg3Pct * 100).toFixed(1),
-        (ftPct * 100).toFixed(1),
-        ast,
-        reb,
-        stl,
-        blk,
-        tov,
-      ])
-    );
-  });
 
   const {
     gp,
@@ -116,8 +184,29 @@ const seasonStatsCompare = ({
       bold(tov),
     ])
   );
+*/
+};
 
-  console.log(seasonTable.toString());
+// make an object where keys are the seasons
+// each season maps to an array of the player stats for that season
+const makeSeasonTable = (playerProfile, seasonStr) => {
+  const seasonObj = {};
+  playerProfile.forEach(player => {
+    // access the season totals for either post or regular season
+    const seasonArr = player[`seasonTotals${seasonStr}`];
+    seasonArr.forEach(season => {
+      const currentSeason = season.seasonId;
+      // check if the season is already in the object
+      if (seasonObj[currentSeason]) {
+        // if it does add this players data to the array
+        seasonObj[currentSeason].push(season);
+      } else {
+        // otherwise create a new array
+        seasonObj[currentSeason] = [season];
+      }
+    });
+  });
+  return seasonObj;
 };
 
 export default seasonStatsCompare;

--- a/src/command/player/seasonStatsCompare.js
+++ b/src/command/player/seasonStatsCompare.js
@@ -3,18 +3,10 @@ import { getMainColor } from 'nba-color';
 
 import { bold } from '../../utils/log';
 import table from '../../utils/table';
-/*
-Author: DoubleB123, bbrenner321@gmail.com
-This is called by index.js when comparing the stats of players
-It is similar to seasonStats.js but a few more steps to 
-compile the data between players for display
-*/
 
 const alignCenter = columns =>
   columns.map(content => ({ content, hAlign: 'center', vAlign: 'center' }));
 
-// takes in an array and gives the index of the max value,
-// ignores the dashes in the array
 const findMaxInd = arr => {
   let maxInd = 0;
   for (let i = 1; i < arr.length; i += 1) {
@@ -27,7 +19,6 @@ const findMaxInd = arr => {
   return maxInd;
 };
 
-// takes in the player info array and gets the names and jersey and creates a string containing them all
 const makeNameStr = (playerInfo, seasonTtpe) => {
   let nameStr = '';
   playerInfo.forEach(player => {
@@ -45,23 +36,16 @@ const makeNameStr = (playerInfo, seasonTtpe) => {
   return nameStr;
 };
 
-// make an object where keys are the seasons
-// each season maps to an array of the player stats for that season
-// each array has the length of the number of players, entries initalized to empty object
 const makeSeasonObj = (playerProfile, seasonStr) => {
   const seasonObj = {};
   let index = 0;
   playerProfile.forEach(player => {
-    // access the season totals for either post or regular season
     const seasonArr = player[`seasonTotals${seasonStr}`];
     seasonArr.forEach(season => {
       const currentSeason = season.seasonId;
-      // check if the season is already in the object
       if (seasonObj[currentSeason]) {
-        // if it does add this players data to the array
         seasonObj[currentSeason][index] = season;
       } else {
-        // otherwise create a new array with length of number of players
         seasonObj[currentSeason] = [...Array(playerProfile.length)].fill({});
         seasonObj[currentSeason][index] = season;
       }
@@ -71,7 +55,6 @@ const makeSeasonObj = (playerProfile, seasonStr) => {
   return seasonObj;
 };
 
-// takes in all the data and returns an array with the player's totals as each entry
 const makeOverall = (playerProfile, seasonStr) => {
   const overallArr = [];
   playerProfile.forEach(player => {
@@ -80,7 +63,6 @@ const makeOverall = (playerProfile, seasonStr) => {
   return overallArr;
 };
 
-// takes in the data for a season and combines the stats into strings to be pushed to table
 /* eslint-disable no-param-reassign */
 const makeRow = seasonData => {
   const template = {
@@ -100,13 +82,10 @@ const makeRow = seasonData => {
   };
   let seasonId;
   seasonData.forEach(player => {
-    // configure certain data before we append to string
-    // make sure object isn't empty
     if (Object.keys(player).length !== 0) {
       player.fg3Pct = (player.fg3Pct * 100).toFixed(1);
       player.fgPct = (player.fgPct * 100).toFixed(1);
       player.ftPct = (player.ftPct * 100).toFixed(1);
-      // overall stats dont have team abbreviation, have to check if exists
       if (player.teamAbbreviation) {
         const teamMainColor = getMainColor(player.teamAbbreviation);
         player.teamAbbreviation = chalk`{bold.white.bgHex('${
@@ -118,47 +97,38 @@ const makeRow = seasonData => {
       }
     }
     Object.keys(template).forEach(key => {
-      // add data to str or if no data put in a dash
       template[key].push(player[key] || '-');
     });
   });
 
   Object.keys(template).forEach(key => {
-    // find which player has best stat and color it green
     const maxInd = findMaxInd(template[key]);
     template[key][maxInd] = chalk.green(template[key][maxInd]);
     template[key] = template[key].join('\n');
   });
 
-  // set seasonId, do this at the end because didnt want key in there when looping
   template.seasonId = seasonId;
   return template;
 };
-/* eslint-enable no-param-reassign */
 
-// main function called by index.js
+/* eslint-enable no-param-reassign */
 const seasonStatsCompare = (
   playerProfile,
   playerInfo,
   seasonTtpe = 'Regular Season'
 ) => {
-  // these strings are used so we can get the correct data at the beginning and dont have to write same code twice
   const seasonStr = seasonTtpe.replace(/\s/g, '');
 
-  // compile the data into a format to push to the table
   const seasonObj = makeSeasonObj(playerProfile, seasonStr);
   const overallArr = makeOverall(playerProfile, seasonStr);
   const nameStr = makeNameStr(playerInfo, seasonTtpe);
 
-  // make sure we are adding rows in the correct order
   const seasonDates = Object.keys(seasonObj).sort((a, b) => {
-    // date has form 2003-04
     const adate = a.split('-')[0];
     const bdate = b.split('-')[0];
     return adate - bdate;
   });
 
-  // use all the strings we generated to make the table
   const seasonTable = table.basicTable();
   seasonTable.push([
     { colSpan: 14, content: nameStr.trim(), hAlign: 'center' },
@@ -182,7 +152,6 @@ const seasonStatsCompare = (
     ])
   );
 
-  // go through each season and push it to table
   seasonDates.reverse().forEach(key => {
     const row = makeRow(seasonObj[key]);
     seasonTable.push(
@@ -205,7 +174,6 @@ const seasonStatsCompare = (
     );
   });
 
-  // add the final Overall row
   const overallRow = makeRow(overallArr);
   seasonTable.push(
     alignCenter([
@@ -225,7 +193,6 @@ const seasonStatsCompare = (
       bold(overallRow.tov.trim()),
     ])
   );
-
   console.log(seasonTable.toString());
 };
 

--- a/src/command/player/seasonStatsCompare.js
+++ b/src/command/player/seasonStatsCompare.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import chalk from 'chalk';
 import { getMainColor } from 'nba-color';
 
@@ -14,16 +13,15 @@ compile the data between players for display
 const alignCenter = columns =>
   columns.map(content => ({ content, hAlign: 'center', vAlign: 'center' }));
 
-//takes in an array and gives the index of the max value,
-//ignores the dashes in the array
-const findMaxInd = arr =>{
+// takes in an array and gives the index of the max value,
+// ignores the dashes in the array
+const findMaxInd = arr => {
   let maxInd = 0;
-  for(let i = 1; i<arr.length; ++i){
-    if(arr[i] === '-'){
-      continue;
-    }
-    if(arr[i] > arr[maxInd]){
-      maxInd = i;
+  for (let i = 1; i < arr.length; i += 1) {
+    if (arr[i] !== '-') {
+      if (arr[i] > arr[maxInd]) {
+        maxInd = i;
+      }
     }
   }
   return maxInd;
@@ -33,7 +31,7 @@ const findMaxInd = arr =>{
 const makeNameStr = (playerInfo, seasonTtpe) => {
   let nameStr = '';
   playerInfo.forEach(player => {
-    const { teamAbbreviation, jersey, displayFirstLast } ={
+    const { teamAbbreviation, jersey, displayFirstLast } = {
       ...player.commonPlayerInfo[0],
     };
     const teamMainColor = getMainColor(teamAbbreviation);
@@ -68,21 +66,22 @@ const makeSeasonObj = (playerProfile, seasonStr) => {
         seasonObj[currentSeason][index] = season;
       }
     });
-    ++index;
+    index += 1;
   });
   return seasonObj;
 };
 
-//takes in all the data and returns an array with the player's totals as each entry
-const makeOverall = (playerProfile, seasonStr) =>{
+// takes in all the data and returns an array with the player's totals as each entry
+const makeOverall = (playerProfile, seasonStr) => {
   const overallArr = [];
-  playerProfile.forEach(player =>{
+  playerProfile.forEach(player => {
     overallArr.push(...player[`careerTotals${seasonStr}`]);
   });
   return overallArr;
 };
 
 // takes in the data for a season and combines the stats into strings to be pushed to table
+/* eslint-disable no-param-reassign */
 const makeRow = seasonData => {
   const template = {
     teamAbbreviation: [],
@@ -97,44 +96,45 @@ const makeRow = seasonData => {
     reb: [],
     stl: [],
     blk: [],
-    tov: []
+    tov: [],
   };
   let seasonId;
   seasonData.forEach(player => {
-    //configure certain data before we append to string
-    //make sure object isn't empty
-    if(Object.keys(player).length !== 0){
-      player.fg3Pct = (player.fg3Pct * 100).toFixed(1)
-      player.fgPct = (player.fgPct * 100).toFixed(1)
-      player.ftPct = (player.ftPct * 100).toFixed(1)
-      //overall stats dont have team abbreviation, have to check if exists
-      if(player.teamAbbreviation){
-        let teamMainColor = getMainColor(player.teamAbbreviation);
+    // configure certain data before we append to string
+    // make sure object isn't empty
+    if (Object.keys(player).length !== 0) {
+      player.fg3Pct = (player.fg3Pct * 100).toFixed(1);
+      player.fgPct = (player.fgPct * 100).toFixed(1);
+      player.ftPct = (player.ftPct * 100).toFixed(1);
+      // overall stats dont have team abbreviation, have to check if exists
+      if (player.teamAbbreviation) {
+        const teamMainColor = getMainColor(player.teamAbbreviation);
         player.teamAbbreviation = chalk`{bold.white.bgHex('${
-            teamMainColor ? teamMainColor.hex : '#000'
-          }') ${player.teamAbbreviation}}`
+          teamMainColor ? teamMainColor.hex : '#000'
+        }') ${player.teamAbbreviation}}`;
       }
-      if(!template.seasonId){
+      if (!template.seasonId) {
         seasonId = bold(player.seasonId);
       }
     }
-    Object.keys(template).forEach(key =>{
-      //add data to str or if no data put in a dash
+    Object.keys(template).forEach(key => {
+      // add data to str or if no data put in a dash
       template[key].push(player[key] || '-');
     });
   });
 
-  Object.keys(template).forEach(key =>{
+  Object.keys(template).forEach(key => {
     // find which player has best stat and color it green
     const maxInd = findMaxInd(template[key]);
     template[key][maxInd] = chalk.green(template[key][maxInd]);
-    template[key] = template[key].join('\n')
-   });
+    template[key] = template[key].join('\n');
+  });
 
-  //set seasonId, do this at the end because didnt want key in there when looping
+  // set seasonId, do this at the end because didnt want key in there when looping
   template.seasonId = seasonId;
   return template;
 };
+/* eslint-enable no-param-reassign */
 
 // main function called by index.js
 const seasonStatsCompare = (
@@ -145,16 +145,16 @@ const seasonStatsCompare = (
   // these strings are used so we can get the correct data at the beginning and dont have to write same code twice
   const seasonStr = seasonTtpe.replace(/\s/g, '');
 
-  //compile the data into a format to push to the table
+  // compile the data into a format to push to the table
   const seasonObj = makeSeasonObj(playerProfile, seasonStr);
   const overallArr = makeOverall(playerProfile, seasonStr);
   const nameStr = makeNameStr(playerInfo, seasonTtpe);
 
   // make sure we are adding rows in the correct order
-  const seasonDates = Object.keys(seasonObj).sort((a,b) => {
-    //date has form 2003-04
-    const adate =a.split('-')[0]
-    const bdate = b.split('-')[0]
+  const seasonDates = Object.keys(seasonObj).sort((a, b) => {
+    // date has form 2003-04
+    const adate = a.split('-')[0];
+    const bdate = b.split('-')[0];
     return adate - bdate;
   });
 
@@ -182,7 +182,7 @@ const seasonStatsCompare = (
     ])
   );
 
-  //go through each season and push it to table
+  // go through each season and push it to table
   seasonDates.reverse().forEach(key => {
     const row = makeRow(seasonObj[key]);
     seasonTable.push(
@@ -200,12 +200,12 @@ const seasonStatsCompare = (
         row.reb.trim(),
         row.stl.trim(),
         row.blk.trim(),
-        row.tov.trim()
+        row.tov.trim(),
       ])
     );
   });
 
-  //add the final Overall row
+  // add the final Overall row
   const overallRow = makeRow(overallArr);
   seasonTable.push(
     alignCenter([
@@ -222,7 +222,7 @@ const seasonStatsCompare = (
       bold(overallRow.reb.trim()),
       bold(overallRow.stl.trim()),
       bold(overallRow.blk.trim()),
-      bold(overallRow.tov.trim())
+      bold(overallRow.tov.trim()),
     ])
   );
 

--- a/src/command/player/seasonStatsCompare.js
+++ b/src/command/player/seasonStatsCompare.js
@@ -1,0 +1,123 @@
+import chalk from 'chalk';
+import { getMainColor } from 'nba-color';
+
+import { bold } from '../../utils/log';
+import table from '../../utils/table';
+
+const alignCenter = columns =>
+  columns.map(content => ({ content, hAlign: 'center', vAlign: 'center' }));
+
+const seasonStatsCompare = ({
+  seasonTtpe,
+  nowTeamAbbreviation,
+  jersey,
+  displayFirstLast,
+  seasonTotals,
+  careerTotals,
+}) => {
+  console.log('comparing');
+  const nowTeamMainColor = getMainColor(nowTeamAbbreviation);
+  const seasonTable = table.basicTable();
+  const playerName = chalk`{bold.white.bgHex('${
+    nowTeamMainColor ? nowTeamMainColor.hex : '#000'
+  }') ${nowTeamAbbreviation}} {bold.white #${jersey} ${displayFirstLast} │ ${
+    seasonTtpe
+  }}`;
+  seasonTable.push([{ colSpan: 14, content: playerName, hAlign: 'center' }]);
+  seasonTable.push(
+    alignCenter([
+      bold('SEASON'),
+      bold('TEAM'),
+      bold('AGE'),
+      bold('GP'),
+      bold('MIN'),
+      bold('PTS'),
+      bold('FG%'),
+      bold('3P%'),
+      bold('FT%'),
+      bold('AST'),
+      bold('REB'),
+      bold('STL'),
+      bold('BLK'),
+      bold('TOV'),
+    ])
+  );
+
+  seasonTotals.reverse().forEach(season => {
+    const {
+      seasonId,
+      teamAbbreviation,
+      playerAge,
+      gp,
+      min,
+      pts,
+      fgPct,
+      fg3Pct,
+      ftPct,
+      ast,
+      reb,
+      stl,
+      blk,
+      tov,
+    } = season;
+    const teamMainColor = getMainColor(teamAbbreviation);
+
+    seasonTable.push(
+      alignCenter([
+        bold(seasonId),
+        chalk`{bold.white.bgHex('${
+          teamMainColor ? teamMainColor.hex : '#000'
+        }') ${teamAbbreviation}}`,
+        playerAge,
+        gp,
+        min,
+        pts,
+        (fgPct * 100).toFixed(1),
+        (fg3Pct * 100).toFixed(1),
+        (ftPct * 100).toFixed(1),
+        ast,
+        reb,
+        stl,
+        blk,
+        tov,
+      ])
+    );
+  });
+
+  const {
+    gp,
+    min,
+    pts,
+    fgPct,
+    fg3Pct,
+    ftPct,
+    ast,
+    reb,
+    stl,
+    blk,
+    tov,
+  } = careerTotals;
+
+  seasonTable.push(
+    alignCenter([
+      bold('Overall'),
+      bold(''),
+      bold(''),
+      bold(gp),
+      bold(min),
+      bold(pts),
+      bold((fgPct * 100).toFixed(1)),
+      bold((fg3Pct * 100).toFixed(1)),
+      bold((ftPct * 100).toFixed(1)),
+      bold(ast),
+      bold(reb),
+      bold(stl),
+      bold(blk),
+      bold(tov),
+    ])
+  );
+
+  console.log(seasonTable.toString());
+};
+
+export default seasonStatsCompare;


### PR DESCRIPTION
Added a -c or --compare flag that lets you compare multiple players. Can be combined with the -i, -r, and -p flags; there is a gif example in the README.

The files that contain most of the code are infoCompare.js and seasonStatsCompare.js, they were based on the existing code in info.js and seasonStats.js. I added a command line switch to cli.js to enable the compare flag. index.js looks like it was changed a lot, but I kept all the existing code intact. I put an if statement around everything to check for the compare flag and if it is there I run my new code and if not I run the existing code. If you have any comments or changes you want me to make let me know.